### PR TITLE
Reintroduce `aws-sdk-cpp` tag to get version that builds and works with this driver

### DIFF
--- a/scripts/build_aws_sdk_win.ps1
+++ b/scripts/build_aws_sdk_win.ps1
@@ -33,6 +33,7 @@ $CURRENT_DIR = (Get-Location).Path
 $SRC_DIR = "${PSScriptRoot}\..\aws_sdk\aws_sdk_cpp"
 $BUILD_DIR = "${SRC_DIR}\..\build"
 $INSTALL_DIR = "${BUILD_DIR}\..\install"
+$AWS_SDK_CPP_TAG = "1.11.371"
 
 $WIN_ARCH = $args[0]
 $CONFIGURATION = $args[1]
@@ -44,7 +45,7 @@ Write-Host $args
 # Make AWS SDK source directory
 New-Item -Path $SRC_DIR -ItemType Directory -Force | Out-Null
 # Clone the AWS SDK CPP repo
-git clone --recurse-submodules "https://github.com/aws/aws-sdk-cpp.git" $SRC_DIR
+git clone --recurse-submodules -b "$AWS_SDK_CPP_TAG" "https://github.com/aws/aws-sdk-cpp.git" $SRC_DIR
 
 # Make and move to build directory
 New-Item -Path $BUILD_DIR -ItemType Directory -Force | Out-Null


### PR DESCRIPTION
### Summary

Using `main` to pull in and build the `aws-sdk-cpp` does not work because it may pull in "breaking" changes.

### Description

Add `$AWS_SDK_CPP_TAG = "1.11.371"` and use it inside `winbuild/BuildAll.ps1`.

### Additional Reviewers

@karenc-bq 

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
