### PR TITLE
Update `aws-rds-odbc` sub module to use main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,4 @@
 [submodule "libs/aws-rds-odbc"]
 	path = libs/aws-rds-odbc
 	url = git@github.com:aws/aws-rds-odbc.git
+	branch = main


### PR DESCRIPTION
### Summary

When this repo is cloned, the `aws-rds-odbc` submodule clone will now use the `main` branch.

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
