### PR TITLE
test: iam integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,25 +2,22 @@ name: Integration Tests
 
 on:
   workflow_dispatch:
-# Temporarily disable running this workflow until
-# integration tests are added.
-#
-#   push:
-#     branches:
-#       - main
-#   pull_request:
-#     branches:
-#       - '*'
-#     paths-ignore:
-#       - '**/*.md'
-#       - '**/*.jpg'
-#       - '**/README.txt'
-#       - '**/LICENSE.txt'
-#       - 'docs/**'
-#       - 'ISSUE_TEMPLATE/**'
-#       - '**/remove-old-artifacts.yml'
-#       - '**/build-installer.yml'
-#       - '**/release.yml'
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.jpg'
+      - '**/README.txt'
+      - '**/LICENSE.txt'
+      - 'docs/**'
+      - 'ISSUE_TEMPLATE/**'
+      - '**/remove-old-artifacts.yml'
+      - '**/build-installer.yml'
+      - '**/release.yml'
 
 env:
   BUILD_TYPE: Release
@@ -80,9 +77,9 @@ jobs:
       - name: 'Run Integration Tests'
         working-directory: ${{ github.workspace }}/testframework
         run: |
-          ./gradlew --no-parallel --no-daemon test-limitless --info
+          ./gradlew --no-parallel --no-daemon test-integration --info
         env:
-          TEST_DSN: awsmysqlodbca
+          TEST_DSN: awspgsqlodbc
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
           AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
@@ -90,13 +87,14 @@ jobs:
           AWS_SESSION_TOKEN: ${{ env.TEMP_AWS_SESSION_TOKEN }}
           AWS_RDS_MONITORING_ROLE_ARN: ${{ secrets.AWS_RDS_MONITORING_ROLE_ARN }}
           RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          TEST_IAM_USER: ${{ secrets.TEST_IAM_USER }}
           DRIVER_PATH: ${{ github.workspace }}
 
       - name: 'Get Github Action IP'
         if: always()
         id: ip
         uses: haythem/public-ip@v1.3
-        
+
       - name: 'Remove Github Action IP'
         if: always()
         run: |

--- a/docs/build-and-test-aws-driver/Test.md
+++ b/docs/build-and-test-aws-driver/Test.md
@@ -164,4 +164,8 @@ This is not something introduced as part of [this pull request](https://github.c
 This behaviour is only seen in Dockerized test environments. This test is passing when run as part of the GitHub CIs.
 
 ### Integration Tests
-*Coming soon*
+1. Set additional environment variables
+|Environment Variable|Description|Example|
+|-|-|-|
+|TEST_IAM_USER|IAM username, used to create a user in the database with IAM authentication|my_iam_user|
+1. Run `.\gradlew --no-parallel test-integration --info`

--- a/test_integration/CMakeLists.txt
+++ b/test_integration/CMakeLists.txt
@@ -1,0 +1,123 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License, version 2.0
+# (GPLv2), as published by the Free Software Foundation, with the
+# following additional permissions:
+#
+# This program is distributed with certain software that is licensed
+# under separate terms, as designated in a particular file or component
+# or in the license documentation. Without limiting your rights under
+# the GPLv2, the authors of this program hereby grant you an additional
+# permission to link the program and your derivative works with the
+# separately licensed software that they have included with the program.
+#
+# Without limiting the foregoing grant of rights under the GPLv2 and
+# additional permission as to separately licensed software, this
+# program is also subject to the Universal FOSS Exception, version 1.0,
+# a copy of which can be found along with its FAQ at
+# http://oss.oracle.com/licenses/universal-foss-exception.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License, version 2.0, for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see 
+# http://www.gnu.org/licenses/gpl-2.0.html. 
+
+cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+project("integration")
+set(CMAKE_CXX_STANDARD 20)
+
+#-----------------------------------------------------
+# Find and add ODBC
+
+if(APPLE)
+  # Required to ensure unixodbc is found and used before iODBC
+  set(ODBC_INCLUDE_DIR /opt/homebrew/opt/unixodbc/include)
+endif()
+
+find_package(ODBC REQUIRED)
+
+message(STATUS "ODBC_INCLUDE_DIRS: ${ODBC_INCLUDE_DIRS}")
+message(STATUS "ODBC_LIBRARIES: ${ODBC_LIBRARIES}")
+include_directories(${ODBC_INCLUDE_DIRS})
+
+#-----------------------------------------------------
+# Google Test
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/v1.15.2.zip
+)
+
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+#-----------------------------------------------------
+# Toxiproxy - Simulate Network Outages
+
+FetchContent_Declare(
+  toxiproxy
+  GIT_REPOSITORY https://github.com/Bit-Quill/toxiproxy-cpp
+  GIT_TAG main
+)
+
+FetchContent_MakeAvailable(toxiproxy)
+
+#-----------------------------------------------------
+
+enable_testing()
+
+add_executable(
+  # Executable Name
+  ${PROJECT_NAME}
+
+  # Runner / Utility
+  connection_string_builder.h
+  integration_test_utils.cc
+  integration_test_utils.h
+
+  # Test Suites
+  connection_string_builder_test.cc
+  iam_authentication_integration_test.cc
+)
+
+include(GoogleTest)
+
+target_link_libraries(
+  # Name
+  ${PROJECT_NAME}
+
+  # External Libaries
+  gtest_main
+  toxiproxy
+  ${ODBC_LIBRARIES}
+)
+
+set_target_properties(
+  ${PROJECT_NAME} 
+  PROPERTIES 
+  RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+)
+
+# Set values to help generate odbc.ini and odbcinst.ini files for Dockerized tests
+SET(ODBC_PATH ${CMAKE_SOURCE_DIR}/../testframework/src/test/resources/)
+SET(TEST_DRIVER "aws-pgsql-odbc")
+SET(DRIVER_PATH $ENV{TEST_DRIVER})
+SET(DRIVER_DESCRIPTION "AWS PG ODBC Driver for connecting to PG")
+SET(THREADING "0")
+
+SET(TEST_DSN $ENV{TEST_DSN})
+SET(TEST_DATABASE $ENV{TEST_DATABASE})
+SET(DESCRIPTION "AWS PG ODBC Driver for Dockerized tests")
+SET(TEST_UID $ENV{TEST_USERNAME})
+
+CONFIGURE_FILE(${ODBC_PATH}/odbc.ini.in     $ENV{ODBCINI} @ONLY)
+CONFIGURE_FILE(${ODBC_PATH}/odbcinst.ini.in $ENV{ODBCINST} @ONLY)

--- a/test_integration/connection_string_builder.h
+++ b/test_integration/connection_string_builder.h
@@ -1,0 +1,492 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0
+// (GPLv2), as published by the Free Software Foundation, with the
+// following additional permissions:
+//
+// This program is distributed with certain software that is licensed
+// under separate terms, as designated in a particular file or component
+// or in the license documentation. Without limiting your rights under
+// the GPLv2, the authors of this program hereby grant you an additional
+// permission to link the program and your derivative works with the
+// separately licensed software that they have included with the program.
+//
+// Without limiting the foregoing grant of rights under the GPLv2 and
+// additional permission as to separately licensed software, this
+// program is also subject to the Universal FOSS Exception, version 1.0,
+// a copy of which can be found along with its FAQ at
+// http://oss.oracle.com/licenses/universal-foss-exception.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see 
+// http://www.gnu.org/licenses/gpl-2.0.html.
+
+#ifndef CONNECTION_STRING_BUILDER_H_
+#define CONNECTION_STRING_BUILDER_H_
+
+#include <stdexcept>
+#include <string>
+#include <memory>
+
+class ConnectionStringBuilder;
+
+class ConnectionString {
+  public:
+    // friend class so the builder can access ConnectionString private attributes
+    friend class ConnectionStringBuilder;
+
+    ConnectionString() : m_dsn(""), m_server(""), m_port(-1),
+                         m_uid(""), m_pwd(""), m_db(""), m_log_query(true),
+                         m_failover_mode(""), m_multi_statements(false), m_enable_cluster_failover(true),
+                         m_failover_timeout(-1), m_connect_timeout(-1), m_network_timeout(-1), m_host_pattern(""),
+                         m_enable_failure_detection(true), m_failure_detection_time(-1), m_failure_detection_timeout(-1),
+                         m_failure_detection_interval(-1), m_failure_detection_count(-1), m_monitor_disposal_time(-1),
+                         m_read_timeout(-1), m_write_timeout(-1), m_auth_mode(""), m_auth_region(""), m_auth_host(""),
+                         m_auth_port(-1), m_auth_expiration(-1), m_secret_id(""),
+                         m_ssl_mode(""),
+
+                         is_set_uid(false), is_set_pwd(false), is_set_db(false), is_set_log_query(false),
+                         is_set_failover_mode(false),
+                         is_set_multi_statements(false), is_set_enable_cluster_failover(false),
+                         is_set_failover_timeout(false), is_set_connect_timeout(false), is_set_network_timeout(false), is_set_host_pattern(false),
+                         is_set_enable_failure_detection(false), is_set_failure_detection_time(false), is_set_failure_detection_timeout(false),
+                         is_set_failure_detection_interval(false), is_set_failure_detection_count(false), is_set_monitor_disposal_time(false),
+                         is_set_read_timeout(false), is_set_write_timeout(false), is_set_auth_mode(false), is_set_auth_region(false),
+                         is_set_auth_host(false), is_set_auth_port(false), is_set_auth_expiration(false), is_set_secret_id(false),
+                         is_set_ssl_mode(false) {};
+
+    std::string get_connection_string() const {
+      char conn_in[4096] = "\0";
+      int length = 0;
+      length += sprintf(conn_in, "DSN=%s;SERVER=%s;PORT=%d;", m_dsn.c_str(), m_server.c_str(), m_port);
+
+      if (is_set_uid) {
+        length += sprintf(conn_in + length, "UID=%s;", m_uid.c_str()); 
+      }
+      if (is_set_pwd) {
+        length += sprintf(conn_in + length, "PWD=%s;", m_pwd.c_str()); 
+      }
+      if (is_set_db) {
+        length += sprintf(conn_in + length, "DATABASE=%s;", m_db.c_str()); 
+      }
+      if (is_set_log_query) {
+        length += sprintf(conn_in + length, "LOG_QUERY=%d;", m_log_query ? 1 : 0); 
+      }
+      if (is_set_failover_mode) {
+        length += sprintf(conn_in + length, "FAILOVER_MODE=%s;", m_failover_mode.c_str());
+      }
+      if (is_set_multi_statements) {
+        length += sprintf(conn_in + length, "MULTI_STATEMENTS=%d;", m_multi_statements ? 1 : 0);
+      }
+      if (is_set_enable_cluster_failover) {
+        length += sprintf(conn_in + length, "ENABLE_CLUSTER_FAILOVER=%d;", m_enable_cluster_failover ? 1 : 0);
+      }
+      if (is_set_failover_timeout) {
+        length += sprintf(conn_in + length, "FAILOVER_TIMEOUT=%d;", m_failover_timeout); 
+      }
+      if (is_set_connect_timeout) {
+        length += sprintf(conn_in + length, "CONNECT_TIMEOUT=%d;", m_connect_timeout); 
+      }
+      if (is_set_network_timeout) {
+        length += sprintf(conn_in + length, "NETWORK_TIMEOUT=%d;", m_network_timeout); 
+      }
+      if (is_set_host_pattern) {
+        length += sprintf(conn_in + length, "HOST_PATTERN=%s;", m_host_pattern.c_str()); 
+      }
+      if (is_set_enable_failure_detection) {
+        length += sprintf(conn_in + length, "ENABLE_FAILURE_DETECTION=%d;", m_enable_failure_detection ? 1 : 0); 
+      }
+      if (is_set_failure_detection_time) {
+        length += sprintf(conn_in + length, "FAILURE_DETECTION_TIME=%d;", m_failure_detection_time);
+      }
+      if (is_set_failure_detection_timeout) {
+        length += sprintf(conn_in + length, "FAILURE_DETECTION_TIMEOUT=%d;", m_failure_detection_timeout);
+      }
+      if (is_set_failure_detection_interval) {
+        length += sprintf(conn_in + length, "FAILURE_DETECTION_INTERVAL=%d;", m_failure_detection_interval);
+      }
+      if (is_set_failure_detection_count) {
+        length += sprintf(conn_in + length, "FAILURE_DETECTION_COUNT=%d;", m_failure_detection_count);
+      }
+      if (is_set_monitor_disposal_time) {
+        length += sprintf(conn_in + length, "MONITOR_DISPOSAL_TIME=%d;", m_monitor_disposal_time);
+      }
+      if (is_set_read_timeout) {
+        length += sprintf(conn_in + length, "READTIMEOUT=%d;", m_read_timeout);
+      }
+      if (is_set_write_timeout) {
+        length += sprintf(conn_in + length, "WRITETIMEOUT=%d;", m_write_timeout);
+      }
+      if (is_set_auth_mode) {
+        length += sprintf(conn_in + length, "AUTHTYPE=%s;", m_auth_mode.c_str());
+      }
+      if (is_set_auth_region) {
+        length += sprintf(conn_in + length, "REGION=%s;", m_auth_region.c_str());
+      }
+      if (is_set_auth_host) {
+        length += sprintf(conn_in + length, "IAM_HOST=%s;", m_auth_host.c_str());
+      }
+      if (is_set_auth_port) {
+        length += sprintf(conn_in + length, "IAM_PORT=%d;", m_auth_port);
+      }
+      if (is_set_auth_expiration) {
+        length += sprintf(conn_in + length, "TOKENEXPIRATION=%d;", m_auth_expiration);
+      }
+      if (is_set_secret_id) {
+        length += sprintf(conn_in + length, "SECRET_ID=%s;", m_secret_id.c_str());
+      }
+      if (is_set_ssl_mode) {
+        length += sprintf(conn_in + length, "SSLmode=%s;", m_ssl_mode.c_str());
+      }
+      snprintf(conn_in + length, sizeof(conn_in) - length, "\0");
+
+      std::string connection_string(conn_in);
+      return connection_string;
+    }
+ 
+  private:
+    // Required fields
+    std::string m_dsn, m_server;
+    int m_port;
+
+    // Optional fields
+    std::string m_uid, m_pwd, m_db;
+    bool m_log_query, m_multi_statements, m_enable_cluster_failover;
+    int m_failover_timeout, m_connect_timeout, m_network_timeout;
+    std::string m_host_pattern, m_failover_mode;
+    bool m_enable_failure_detection;
+    int m_failure_detection_time, m_failure_detection_timeout, m_failure_detection_interval, m_failure_detection_count, m_monitor_disposal_time, m_read_timeout, m_write_timeout;
+    std::string m_auth_mode, m_auth_region, m_auth_host, m_secret_id;
+    int m_auth_port, m_auth_expiration;
+    std::string m_ssl_mode;
+
+    bool is_set_uid, is_set_pwd, is_set_db;
+    bool is_set_log_query, is_set_failover_mode, is_set_multi_statements;
+    bool is_set_enable_cluster_failover;
+    bool is_set_failover_timeout, is_set_connect_timeout, is_set_network_timeout;
+    bool is_set_host_pattern;
+    bool is_set_enable_failure_detection;
+    bool is_set_failure_detection_time, is_set_failure_detection_timeout, is_set_failure_detection_interval, is_set_failure_detection_count;
+    bool is_set_monitor_disposal_time;
+    bool is_set_read_timeout, is_set_write_timeout;
+    bool is_set_auth_mode, is_set_auth_region, is_set_auth_host, is_set_auth_port, is_set_auth_expiration, is_set_secret_id;
+    bool is_set_ssl_mode;
+
+    void set_dsn(const std::string& dsn) {
+      m_dsn = dsn;
+    }
+
+    void set_server(const std::string& server) {
+      m_server = server;
+    }
+
+    void set_port(const int& port) {
+      m_port = port;
+    }
+
+    void set_uid(const std::string& uid) {
+      m_uid = uid;
+      is_set_uid = true;
+    }
+
+    void set_pwd(const std::string& pwd) {
+      m_pwd = pwd;
+      is_set_pwd = true;
+    }
+
+    void set_db(const std::string& db) {
+      m_db = db;
+      is_set_db = true;
+    }
+
+    void set_log_query(const bool& log_query) {
+      m_log_query = log_query;
+      is_set_log_query = true;
+    }
+
+    void set_failover_mode(const std::string& failover_mode) {
+      m_failover_mode = failover_mode;
+      is_set_failover_mode = true;
+    }
+
+    void set_multi_statements(const bool& multi_statements) {
+      m_multi_statements = multi_statements;
+      is_set_multi_statements = true;
+    }
+
+    void set_enable_cluster_failover(const bool& enable_cluster_failover) {
+      m_enable_cluster_failover = enable_cluster_failover;
+      is_set_enable_cluster_failover = true;
+    }
+
+    void set_failover_timeout(const int& failover_timeout) {
+      m_failover_timeout = failover_timeout;
+      is_set_failover_timeout = true;
+    }
+
+    void set_connect_timeout(const int& connect_timeout) {
+      m_connect_timeout = connect_timeout;
+      is_set_connect_timeout = true;
+    }
+
+    void set_network_timeout(const int& network_timeout) {
+      m_network_timeout = network_timeout;
+      is_set_network_timeout = true;
+    }
+
+    void set_host_pattern(const std::string& host_pattern) {
+      m_host_pattern = host_pattern;
+      is_set_host_pattern = true;
+    }
+
+    void set_enable_failure_detection(const bool& enable_failure_detection) {
+      m_enable_failure_detection = enable_failure_detection;
+      is_set_enable_failure_detection = true;
+    }
+
+    void set_failure_detection_time(const int& failure_detection_time) {
+      m_failure_detection_time = failure_detection_time;
+      is_set_failure_detection_time = true;
+    }
+
+    void set_failure_detection_timeout(const int& failure_detection_timeout) {
+      m_failure_detection_timeout = failure_detection_timeout;
+      is_set_failure_detection_timeout = true;
+    }
+
+    void set_failure_detection_interval(const int& failure_detection_interval) {
+      m_failure_detection_interval = failure_detection_interval;
+      is_set_failure_detection_interval = true;
+    }
+
+    void set_failure_detection_count(const int& failure_detection_count) {
+      m_failure_detection_count = failure_detection_count;
+      is_set_failure_detection_count = true;
+    }
+
+    void set_monitor_disposal_time(const int& monitor_disposal_time) {
+      m_monitor_disposal_time = monitor_disposal_time;
+      is_set_monitor_disposal_time = true;
+    }
+
+    void set_read_timeout(const int& read_timeout) {
+      m_read_timeout = read_timeout;
+      is_set_read_timeout = true;
+    }
+
+    void set_write_timeout(const int& write_timeout) {
+      m_write_timeout = write_timeout;
+      is_set_write_timeout = true;
+    }
+
+    void set_auth_mode(const std::string& auth_mode) {
+        m_auth_mode = auth_mode;
+        is_set_auth_mode = true;
+    }
+
+    void set_auth_region(const std::string& auth_region) {
+        m_auth_region = auth_region;
+        is_set_auth_region = true;
+    }
+
+    void set_auth_host(const std::string& auth_host) {
+        m_auth_host = auth_host;
+        is_set_auth_host = true;
+    }
+
+    void set_auth_port(const int& auth_port) {
+        m_auth_port = auth_port;
+        is_set_auth_port = true;
+    }
+
+    void set_auth_expiration(const int& auth_expiration) {
+        m_auth_expiration = auth_expiration;
+        is_set_auth_expiration = true;
+    }
+
+    void set_secret_id(const std::string& secret_id) {
+        m_secret_id = secret_id;
+        is_set_secret_id = true;
+    }
+
+    void set_ssl_mode(const std::string& ssl_mode) {
+        m_ssl_mode = ssl_mode;
+        is_set_ssl_mode = true;
+    }
+};
+
+class ConnectionStringBuilder {
+  public:
+    ConnectionStringBuilder() {
+      connection_string.reset(new ConnectionString());
+    }
+    
+    ConnectionStringBuilder& withDSN(const std::string& dsn) {
+      connection_string->set_dsn(dsn);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withServer(const std::string& server) {
+      connection_string->set_server(server);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withPort(const int& port) {
+      connection_string->set_port(port);
+      return *this;
+    }
+    
+    ConnectionStringBuilder& withUID(const std::string& uid) {
+      connection_string->set_uid(uid);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withPWD(const std::string& pwd) {
+      connection_string->set_pwd(pwd);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withDatabase(const std::string& db) {
+      connection_string->set_db(db);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withLogQuery(const bool& log_query) {
+      connection_string->set_log_query(log_query);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withFailoverMode(const std::string& failover_mode) {
+      connection_string->set_failover_mode(failover_mode);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withMultiStatements(const bool& multi_statements) {
+      connection_string->set_multi_statements(multi_statements);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withEnableClusterFailover(const bool& enable_cluster_failover) {
+      connection_string->set_enable_cluster_failover(enable_cluster_failover);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withFailoverTimeout(const int& failover_t) {
+      connection_string->set_failover_timeout(failover_t);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withConnectTimeout(const int& connect_timeout) {
+      connection_string->set_connect_timeout(connect_timeout);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withNetworkTimeout(const int& network_timeout) {
+      connection_string->set_network_timeout(network_timeout);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withHostPattern(const std::string& host_pattern) {
+      connection_string->set_host_pattern(host_pattern);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withEnableFailureDetection(const bool& enable_failure_detection) {
+      connection_string->set_enable_failure_detection(enable_failure_detection);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withFailureDetectionTime(const int& failure_detection_time) {
+      connection_string->set_failure_detection_time(failure_detection_time);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withFailureDetectionTimeout(const int& failure_detection_timeout) {
+      connection_string->set_failure_detection_timeout(failure_detection_timeout);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withFailureDetectionInterval(const int& failure_detection_interval) {
+      connection_string->set_failure_detection_interval(failure_detection_interval);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withFailureDetectionCount(const int& failure_detection_count) {
+      connection_string->set_failure_detection_count(failure_detection_count);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withMonitorDisposalTime(const int& monitor_disposal_time) {
+      connection_string->set_monitor_disposal_time(monitor_disposal_time);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withReadTimeout(const int& read_timeout) {
+      connection_string->set_read_timeout(read_timeout);
+      return *this;
+    }
+    
+    ConnectionStringBuilder& withWriteTimeout(const int& write_timeout) {
+      connection_string->set_write_timeout(write_timeout);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withAuthMode(const std::string& auth_mode) {
+      connection_string->set_auth_mode(auth_mode);
+      return *this;
+    }
+
+    ConnectionStringBuilder& withAuthRegion(const std::string& auth_region) {
+        connection_string->set_auth_region(auth_region);
+        return *this;
+    }
+
+    ConnectionStringBuilder& withAuthHost(const std::string& auth_host) {
+        connection_string->set_auth_host(auth_host);
+        return *this;
+    }
+
+    ConnectionStringBuilder& withAuthPort(const int& auth_port) {
+        connection_string->set_auth_port(auth_port);
+        return *this;
+    }
+
+    ConnectionStringBuilder& withAuthExpiration(const int& auth_expiration) {
+        connection_string->set_auth_expiration(auth_expiration);
+        return *this;
+    }
+
+    ConnectionStringBuilder& withSecretId(const std::string& secret_id) {
+        connection_string->set_secret_id(secret_id);
+        return *this;
+    }
+
+    ConnectionStringBuilder& withSslMode(const std::string& ssl_mode) {
+        connection_string->set_ssl_mode(ssl_mode);
+        return *this;
+    }
+
+    std::string build() const {
+      if (connection_string->m_dsn.empty()) {
+        throw std::runtime_error("DSN is a required field in a connection string.");
+      }
+      if (connection_string->m_server.empty()) {
+        throw std::runtime_error("Server is a required field in a connection string.");
+      }
+      if (connection_string->m_port < 1) {
+        throw std::runtime_error("Port is a required field in a connection string.");
+      }
+      return connection_string->get_connection_string();
+    }
+    
+  private:
+    std::unique_ptr<ConnectionString> connection_string;
+};
+
+#endif // CONNECTION_STRING_BUILDER_H_

--- a/test_integration/connection_string_builder_test.cc
+++ b/test_integration/connection_string_builder_test.cc
@@ -1,0 +1,170 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0
+// (GPLv2), as published by the Free Software Foundation, with the
+// following additional permissions:
+//
+// This program is distributed with certain software that is licensed
+// under separate terms, as designated in a particular file or component
+// or in the license documentation. Without limiting your rights under
+// the GPLv2, the authors of this program hereby grant you an additional
+// permission to link the program and your derivative works with the
+// separately licensed software that they have included with the program.
+//
+// Without limiting the foregoing grant of rights under the GPLv2 and
+// additional permission as to separately licensed software, this
+// program is also subject to the Universal FOSS Exception, version 1.0,
+// a copy of which can be found along with its FAQ at
+// http://oss.oracle.com/licenses/universal-foss-exception.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see 
+// http://www.gnu.org/licenses/gpl-2.0.html.
+
+#include <gtest/gtest.h>
+
+#include "connection_string_builder.h"
+
+class ConnectionStringBuilderTest : public testing::Test {
+};
+
+// No fields are set in the builder. Error expected.
+TEST_F(ConnectionStringBuilderTest, test_empty_builder) {
+  ConnectionStringBuilder builder = ConnectionStringBuilder();
+  EXPECT_THROW(builder.build(), std::runtime_error);
+}
+
+// More than one required field is not set in the builder. Error expected.
+TEST_F(ConnectionStringBuilderTest, test_missing_fields) {
+  ConnectionStringBuilder builder = ConnectionStringBuilder();
+  EXPECT_THROW(builder.withServer("testServer").build(), std::runtime_error);
+}
+
+// Required field DSN is not set in the builder. Error expected.
+TEST_F(ConnectionStringBuilderTest, test_missing_dsn) {
+  ConnectionStringBuilder builder = ConnectionStringBuilder();
+  EXPECT_THROW(builder.withServer("testServer").withPort(3306).build(), std::runtime_error);
+}
+
+// Required field Server is not set in the builder. Error expected.
+TEST_F(ConnectionStringBuilderTest, test_missing_server) {
+  ConnectionStringBuilder builder = ConnectionStringBuilder();
+  EXPECT_THROW(builder.withDSN("testDSN").withPort(3306).build(), std::runtime_error);
+}
+
+// Required field Port is not set in the builder. Error expected.
+TEST_F(ConnectionStringBuilderTest, test_missing_port) {
+  ConnectionStringBuilder builder = ConnectionStringBuilder();
+  EXPECT_THROW(builder.withDSN("testDSN").withServer("testServer").build(), std::runtime_error);
+}
+
+// All connection string fields are set in the builder.
+TEST_F(ConnectionStringBuilderTest, test_complete_string) {
+  ConnectionStringBuilder builder = ConnectionStringBuilder();
+  const std::string connection_string = builder.withServer("testServer")
+                                   .withUID("testUser")
+                                   .withPWD("testPwd")
+                                   .withLogQuery(false)
+                                   .withMultiStatements(false)
+                                   .withDSN("testDSN")
+                                   .withFailoverTimeout(120000)
+                                   .withPort(3306)
+                                   .withDatabase("testDb")
+                                   .withConnectTimeout(20)
+                                   .withNetworkTimeout(20)
+                                   .withHostPattern("?.testDomain")
+                                   .withEnableFailureDetection(true)
+                                   .withFailureDetectionTime(10000)
+                                   .withFailureDetectionInterval(100)
+                                   .withFailureDetectionCount(4)
+                                   .withMonitorDisposalTime(300)
+                                   .withEnableClusterFailover(true)
+                                   .build();
+
+  const std::string expected = "DSN=testDSN;SERVER=testServer;PORT=3306;UID=testUser;PWD=testPwd;DATABASE=testDb;LOG_QUERY=0;MULTI_STATEMENTS=0;ENABLE_CLUSTER_FAILOVER=1;FAILOVER_TIMEOUT=120000;CONNECT_TIMEOUT=20;NETWORK_TIMEOUT=20;HOST_PATTERN=?.testDomain;ENABLE_FAILURE_DETECTION=1;FAILURE_DETECTION_TIME=10000;FAILURE_DETECTION_INTERVAL=100;FAILURE_DETECTION_COUNT=4;MONITOR_DISPOSAL_TIME=300;";
+  EXPECT_EQ(0, expected.compare(connection_string));
+}
+
+// No optional fields are set in the builder. Build will succeed. Connection string with required fields.
+TEST_F(ConnectionStringBuilderTest, test_only_required_fields) {
+  ConnectionStringBuilder builder = ConnectionStringBuilder();
+  const std::string connection_string = builder.withDSN("testDSN")
+                                   .withServer("testServer")
+                                   .withPort(3306)
+                                   .build();
+
+  const std::string expected = "DSN=testDSN;SERVER=testServer;PORT=3306;";
+  EXPECT_EQ(0, expected.compare(connection_string));
+}
+
+// Some optional fields are set and others not set in the builder. Build will succeed.
+// Connection string with required fields and ONLY the fields that were set.
+TEST_F(ConnectionStringBuilderTest, test_some_optional) {
+  ConnectionStringBuilder builder = ConnectionStringBuilder();
+  const std::string connection_string = builder.withDSN("testDSN")
+                                   .withServer("testServer")
+                                   .withPort(3306)
+                                   .withUID("testUser")
+                                   .withPWD("testPwd")
+                                   .build();
+
+  const std::string expected("DSN=testDSN;SERVER=testServer;PORT=3306;UID=testUser;PWD=testPwd;");
+  EXPECT_EQ(0, expected.compare(connection_string));
+}
+
+// Boolean values are set in the builder. Build will succeed. True will be marked as 1 in the string, false 0.
+TEST_F(ConnectionStringBuilderTest, test_setting_boolean_fields) {
+  ConnectionStringBuilder builder = ConnectionStringBuilder();
+  const std::string connection_string = builder.withDSN("testDSN")
+                                   .withServer("testServer")
+                                   .withPort(3306)
+                                   .withUID("testUser")
+                                   .withPWD("testPwd")
+                                   .withLogQuery(false)
+                                   .withMultiStatements(true)
+                                   .withEnableClusterFailover(false)
+                                   .withEnableFailureDetection(true)
+                                   .build();
+
+  const std::string expected("DSN=testDSN;SERVER=testServer;PORT=3306;UID=testUser;PWD=testPwd;LOG_QUERY=0;MULTI_STATEMENTS=1;ENABLE_CLUSTER_FAILOVER=0;ENABLE_FAILURE_DETECTION=1;");
+  EXPECT_EQ(0, expected.compare(connection_string));
+}
+
+// Create a builder with required values. Then append other properties to the builder. Then build the connection string. Build will succeed.
+TEST_F(ConnectionStringBuilderTest, test_setting_multiple_steps_1) {
+  ConnectionStringBuilder builder = ConnectionStringBuilder();
+  builder.withDSN("testDSN").withServer("testServer").withPort(3306);
+
+  builder.withUID("testUser").withPWD("testPwd").withLogQuery(true);
+  const std::string connection_string = builder.build();
+
+  const std::string expected("DSN=testDSN;SERVER=testServer;PORT=3306;UID=testUser;PWD=testPwd;LOG_QUERY=1;");
+  EXPECT_EQ(0, expected.compare(connection_string));
+}
+
+// Create a builder initially without all required values. Then append other properties to the builder.
+// After second round of values, all required values are set. Build the connection string. Build will succeed.
+TEST_F(ConnectionStringBuilderTest, test_setting_multiple_steps_2) {
+  ConnectionStringBuilder builder = ConnectionStringBuilder();
+  builder.withDSN("testDSN").withServer("testServer").withUID("testUser").withPWD("testPwd");
+
+  builder.withPort(3306).withLogQuery(true);
+  const std::string connection_string = builder.build();
+
+  const std::string expected("DSN=testDSN;SERVER=testServer;PORT=3306;UID=testUser;PWD=testPwd;LOG_QUERY=1;");
+  EXPECT_EQ(0, expected.compare(connection_string));
+}
+
+// Create a builder with some values. Then append more values to the builder, but leaving required values unset.
+// Then build the connection string. Error expected.
+TEST_F(ConnectionStringBuilderTest, test_multiple_steps_without_required) {
+  ConnectionStringBuilder builder = ConnectionStringBuilder();
+  builder.withServer("testServer").withPort(3306);
+  EXPECT_THROW(builder.withUID("testUser").withPWD("testPwd").withLogQuery(true).build(), std::runtime_error);
+}

--- a/test_integration/iam_authentication_integration_test.cc
+++ b/test_integration/iam_authentication_integration_test.cc
@@ -1,0 +1,274 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0
+// (GPLv2), as published by the Free Software Foundation, with the
+// following additional permissions:
+//
+// This program is distributed with certain software that is licensed
+// under separate terms, as designated in a particular file or component
+// or in the license documentation. Without limiting your rights under
+// the GPLv2, the authors of this program hereby grant you an additional
+// permission to link the program and your derivative works with the
+// separately licensed software that they have included with the program.
+//
+// Without limiting the foregoing grant of rights under the GPLv2 and
+// additional permission as to separately licensed software, this
+// program is also subject to the Universal FOSS Exception, version 1.0,
+// a copy of which can be found along with its FAQ at
+// http://oss.oracle.com/licenses/universal-foss-exception.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see 
+// http://www.gnu.org/licenses/gpl-2.0.html.
+
+#include <gtest/gtest.h>
+
+#ifdef WIN32
+#include <windows.h>
+#endif
+
+#include <sql.h>
+#include <sqlext.h>
+
+#include "connection_string_builder.h"
+#include "integration_test_utils.h"
+
+// Connection string parameters
+static char* test_dsn;
+static char* test_db;
+static char* test_user;
+static char* test_pwd;
+static unsigned int test_port;
+static char* iam_user;
+static char* test_region;
+
+static std::string test_endpoint;
+
+#include <iostream>
+
+class IamAuthenticationIntegrationTest : public testing::Test {
+protected:
+    ConnectionStringBuilder builder;
+    SQLHENV env = nullptr;
+    SQLHDBC dbc = nullptr;
+
+    static void SetUpTestSuite() {
+        test_endpoint = std::getenv("TEST_SERVER");
+        test_dsn = std::getenv("TEST_DSN");
+        test_db = std::getenv("TEST_DATABASE");
+        test_user = std::getenv("TEST_USERNAME");
+        test_pwd = std::getenv("TEST_PASSWORD");
+        // Cast to remove const
+        test_port = INTEGRATION_TEST_UTILS::str_to_int(
+            INTEGRATION_TEST_UTILS::get_env_var("POSTGRES_PORT", (char*) "5432"));
+        iam_user = INTEGRATION_TEST_UTILS::get_env_var("IAM_USER", (char*) "john_doe");
+        test_region = INTEGRATION_TEST_UTILS::get_env_var("RDS_REGION", (char*) "us-east-2");
+
+        // Connect to execute SQL query to add IAM user to DB        
+        auto conn_str_builder = ConnectionStringBuilder();
+        auto conn_str = conn_str_builder
+            .withDSN(test_dsn)
+            .withServer(test_endpoint)
+            .withUID(test_user)
+            .withPWD(test_pwd)
+            .withPort(test_port)
+            .withDatabase(test_db).build();
+
+        SQLHENV env1 = nullptr;
+        SQLHDBC dbc1 = nullptr;
+        SQLAllocHandle(SQL_HANDLE_ENV, nullptr, &env1);
+        SQLSetEnvAttr(env1, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+        SQLAllocHandle(SQL_HANDLE_DBC, env1, &dbc1);
+
+        SQLCHAR conn_out[4096] = "\0";
+        SQLSMALLINT len;
+        EXPECT_EQ(SQL_SUCCESS, 
+            SQLDriverConnect(dbc1, nullptr, AS_SQLCHAR(conn_str.c_str()), SQL_NTS,
+                conn_out, MAX_NAME_LEN, &len, SQL_DRIVER_NOPROMPT));
+
+        SQLHSTMT stmt = nullptr;
+        EXPECT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_STMT, dbc1, &stmt));
+
+        char query_buffer[200];
+        sprintf(query_buffer, "DROP USER IF EXISTS %s;", iam_user);
+        SQLExecDirect(stmt, AS_SQLCHAR(query_buffer), SQL_NTS);
+
+        memset(query_buffer, 0, sizeof(query_buffer));
+        sprintf(query_buffer, "CREATE USER %s;", iam_user);
+        EXPECT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, AS_SQLCHAR(query_buffer), SQL_NTS));
+
+        memset(query_buffer, 0, sizeof(query_buffer));
+        sprintf(query_buffer, "GRANT rds_iam TO %s;", iam_user);
+        EXPECT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, AS_SQLCHAR(query_buffer), SQL_NTS));
+
+        EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_STMT, stmt));
+        EXPECT_EQ(SQL_SUCCESS, SQLDisconnect(dbc1));
+        
+        if (nullptr != stmt) {
+            SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+        }
+        if (nullptr != dbc1) {
+            SQLDisconnect(dbc1);
+            SQLFreeHandle(SQL_HANDLE_DBC, dbc1);
+        }
+        if (nullptr != env1) {
+            SQLFreeHandle(SQL_HANDLE_ENV, env1);
+        }
+    }
+
+    static void TearDownTestSuite() {
+    }
+
+    void SetUp() override {
+        SQLAllocHandle(SQL_HANDLE_ENV, nullptr, &env);
+        SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+        SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
+
+        builder = ConnectionStringBuilder();
+        builder
+            .withDSN(test_dsn)
+            .withDatabase(test_db)
+            .withAuthMode("IAM")
+            .withAuthRegion(test_region)
+            .withAuthExpiration(900)
+            .withSslMode("allow");
+    }
+
+    void TearDown() override {
+        if (nullptr != dbc) {
+            SQLFreeHandle(SQL_HANDLE_DBC, dbc);
+        }
+        if (nullptr != env) {
+            SQLFreeHandle(SQL_HANDLE_ENV, env);
+        }
+    }
+};
+
+// Tests a simple IAM connection with all expected fields provided.
+TEST_F(IamAuthenticationIntegrationTest, SimpleIamConnection) {
+    auto connection_string = builder
+        .withServer(test_endpoint)
+        .withUID(iam_user)
+        .withPort(test_port)
+        .withAuthPort(test_port).build();
+
+    SQLCHAR conn_out[4096] = "\0";
+    SQLSMALLINT len;
+    SQLRETURN rc = SQLDriverConnect(dbc, nullptr, AS_SQLCHAR(connection_string.c_str()), SQL_NTS,
+        conn_out, MAX_NAME_LEN, &len, SQL_DRIVER_NOPROMPT);
+    EXPECT_EQ(SQL_SUCCESS, rc);
+
+    rc = SQLDisconnect(dbc);
+    EXPECT_EQ(SQL_SUCCESS, rc);
+}
+
+// Tests that IAM connection will still connect via the provided port
+// when the auth port is not provided.
+TEST_F(IamAuthenticationIntegrationTest, PortWithNoAuthPort) {
+    auto connection_string = builder
+        .withServer(test_endpoint)
+        .withUID(iam_user)
+        .withPort(test_port).build();
+
+    SQLCHAR conn_out[4096] = "\0";
+    SQLSMALLINT len;
+    SQLRETURN rc = SQLDriverConnect(dbc, nullptr, AS_SQLCHAR(connection_string.c_str()), SQL_NTS,
+        conn_out, MAX_NAME_LEN, &len, SQL_DRIVER_NOPROMPT);
+    EXPECT_EQ(SQL_SUCCESS, rc);
+
+    rc = SQLDisconnect(dbc);
+    EXPECT_EQ(SQL_SUCCESS, rc);
+}
+
+// Tests that IAM connection will still connect
+// when given an IP address instead of a cluster name.
+// DISABLED - PG is unable to connect using the token generated from an IP address as the host
+TEST_F(IamAuthenticationIntegrationTest, DISABLED_ConnectToIpAddress) {
+    auto ip_address = INTEGRATION_TEST_UTILS::host_to_IP(test_endpoint);
+    
+    auto connection_string = builder
+        .withServer(ip_address)
+        .withUID(iam_user)
+        .withPort(test_port).build();
+
+    SQLCHAR conn_out[4096] = "\0";
+    SQLSMALLINT len;
+    SQLRETURN rc = SQLDriverConnect(dbc, nullptr, AS_SQLCHAR(connection_string.c_str()), SQL_NTS,
+        conn_out, MAX_NAME_LEN, &len, SQL_DRIVER_NOPROMPT);
+    EXPECT_EQ(SQL_SUCCESS, rc);
+    
+    rc = SQLDisconnect(dbc);
+    EXPECT_EQ(SQL_SUCCESS, rc);
+}
+
+// Tests that IAM connection will still connect
+// when given a wrong password (because the password gets replaced by the auth token).
+TEST_F(IamAuthenticationIntegrationTest, WrongPassword) {
+    auto connection_string = builder
+        .withServer(test_endpoint)
+        .withUID(iam_user)
+        .withPWD("WRONG_PASSWORD")
+        .withPort(test_port).build();
+
+    SQLCHAR conn_out[4096] = "\0";
+    SQLSMALLINT len;
+    SQLRETURN rc = SQLDriverConnect(dbc, nullptr, AS_SQLCHAR(connection_string.c_str()), SQL_NTS,
+        conn_out, MAX_NAME_LEN, &len, SQL_DRIVER_NOPROMPT);
+    EXPECT_EQ(SQL_SUCCESS, rc);
+
+    rc = SQLDisconnect(dbc);
+    EXPECT_EQ(SQL_SUCCESS, rc);
+}
+
+// Tests that the IAM connection will fail when provided a wrong user.
+TEST_F(IamAuthenticationIntegrationTest, WrongUser) {
+    auto connection_string = builder
+        .withServer(test_endpoint)
+        .withUID("WRONG_USER")
+        .withPort(test_port).build();
+
+    SQLCHAR conn_out[4096] = "\0";
+    SQLSMALLINT len;
+    SQLRETURN rc = SQLDriverConnect(dbc, nullptr, AS_SQLCHAR(connection_string.c_str()), SQL_NTS,
+        conn_out, MAX_NAME_LEN, &len, SQL_DRIVER_NOPROMPT);
+    EXPECT_EQ(SQL_ERROR, rc);
+
+    SQLSMALLINT stmt_length;
+    SQLINTEGER native_err;
+    SQLCHAR msg[SQL_MAX_MESSAGE_LENGTH] = "\0", state[6] = "\0";
+    rc = SQLError(nullptr, dbc, nullptr, state, &native_err,
+        msg, SQL_MAX_MESSAGE_LENGTH - 1, &stmt_length);
+    EXPECT_EQ(SQL_SUCCESS, rc);
+    const std::string state_str = reinterpret_cast<char*>(state);    
+    EXPECT_EQ("08S01", state_str);
+}
+
+// Tests that the IAM connection will fail when provided an empty user.
+TEST_F(IamAuthenticationIntegrationTest, EmptyUser) {
+    auto connection_string = builder
+        .withServer(test_endpoint)
+        .withAuthHost(test_endpoint)
+        .withUID("")
+        .withPort(test_port).build();
+
+    SQLCHAR conn_out[4096] = "\0";
+    SQLSMALLINT len;
+    SQLRETURN rc = SQLDriverConnect(dbc, nullptr, AS_SQLCHAR(connection_string.c_str()), SQL_NTS,
+        conn_out, MAX_NAME_LEN, &len, SQL_DRIVER_NOPROMPT);
+    EXPECT_EQ(SQL_ERROR, rc);
+
+    SQLSMALLINT stmt_length;
+    SQLINTEGER native_err;
+    SQLCHAR msg[SQL_MAX_MESSAGE_LENGTH] = "\0", state[6] = "\0";
+    rc = SQLError(nullptr, dbc, nullptr, state, &native_err,
+        msg, SQL_MAX_MESSAGE_LENGTH - 1, &stmt_length);
+    EXPECT_EQ(SQL_SUCCESS, rc);
+    const std::string state_str = reinterpret_cast<char*>(state);
+    EXPECT_EQ("08S01", state_str);
+}

--- a/test_integration/integration_test_utils.cc
+++ b/test_integration/integration_test_utils.cc
@@ -1,0 +1,92 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0
+// (GPLv2), as published by the Free Software Foundation, with the
+// following additional permissions:
+//
+// This program is distributed with certain software that is licensed
+// under separate terms, as designated in a particular file or component
+// or in the license documentation. Without limiting your rights under
+// the GPLv2, the authors of this program hereby grant you an additional
+// permission to link the program and your derivative works with the
+// separately licensed software that they have included with the program.
+//
+// Without limiting the foregoing grant of rights under the GPLv2 and
+// additional permission as to separately licensed software, this
+// program is also subject to the Universal FOSS Exception, version 1.0,
+// a copy of which can be found along with its FAQ at
+// http://oss.oracle.com/licenses/universal-foss-exception.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see 
+// http://www.gnu.org/licenses/gpl-2.0.html.
+
+
+#include <gtest/gtest.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <stdio.h>
+#pragma comment(lib, "Ws2_32.lib")
+#else
+#include <arpa/inet.h>
+#include <netdb.h>
+#endif
+
+#include "integration_test_utils.h"
+
+char* INTEGRATION_TEST_UTILS::get_env_var(const char* key, char* default_value) {
+    char* value = std::getenv(key);
+    if (value == nullptr || value == "") {
+        return default_value;
+    }
+
+    return value;
+}
+
+int INTEGRATION_TEST_UTILS::str_to_int(const char* str) {
+    const long int x = strtol(str, nullptr, 10);
+    assert(x <= INT_MAX);
+    assert(x >= INT_MIN);
+    return static_cast<int>(x);
+}
+
+std::string INTEGRATION_TEST_UTILS::host_to_IP(std::string hostname) {
+#ifdef _WIN32
+    WSADATA wsaData;
+    WSAStartup(MAKEWORD(2,2), &wsaData);
+#endif
+    int status;
+    struct addrinfo hints;
+    struct addrinfo* servinfo;
+    struct addrinfo* p;
+    char ipstr[INET_ADDRSTRLEN];
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET; //IPv4
+    hints.ai_socktype = SOCK_STREAM;
+
+    if ((status = getaddrinfo(hostname.c_str(), NULL, &hints, &servinfo)) != 0) {
+        ADD_FAILURE() << "The IP address of host " << hostname << " could not be determined."
+            << "getaddrinfo error:" << gai_strerror(status);
+        return {};
+    }
+
+    for (p = servinfo; p != NULL; p = p->ai_next) {
+        void* addr;
+
+        struct sockaddr_in* ipv4 = (struct sockaddr_in*)p->ai_addr;
+        addr = &(ipv4->sin_addr);
+        inet_ntop(p->ai_family, addr, ipstr, sizeof(ipstr));
+    }
+
+    freeaddrinfo(servinfo);
+    return std::string(ipstr);
+}

--- a/test_integration/integration_test_utils.h
+++ b/test_integration/integration_test_utils.h
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0
+// (GPLv2), as published by the Free Software Foundation, with the
+// following additional permissions:
+//
+// This program is distributed with certain software that is licensed
+// under separate terms, as designated in a particular file or component
+// or in the license documentation. Without limiting your rights under
+// the GPLv2, the authors of this program hereby grant you an additional
+// permission to link the program and your derivative works with the
+// separately licensed software that they have included with the program.
+//
+// Without limiting the foregoing grant of rights under the GPLv2 and
+// additional permission as to separately licensed software, this
+// program is also subject to the Universal FOSS Exception, version 1.0,
+// a copy of which can be found along with its FAQ at
+// http://oss.oracle.com/licenses/universal-foss-exception.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see 
+// http://www.gnu.org/licenses/gpl-2.0.html.
+
+#ifndef INTEGRATIONTESTUTILS_H_
+#define INTEGRATIONTESTUTILS_H_
+
+#define MAX_NAME_LEN 4096
+#define SQL_MAX_MESSAGE_LENGTH 512
+
+#define AS_SQLCHAR(str) const_cast<SQLCHAR*>(reinterpret_cast<const SQLCHAR*>(str))
+
+class INTEGRATION_TEST_UTILS {
+public:
+    static char* get_env_var(const char* key, char* default_value);
+    static int str_to_int(const char* str);
+    static std::string host_to_IP(std::string hostname);
+};
+
+#endif // INTEGRATIONTESTUTILS_H_

--- a/testframework/build.gradle.kts
+++ b/testframework/build.gradle.kts
@@ -37,6 +37,10 @@ tasks.register<Test>("test-performance") {
     filter.includeTestsMatching("host.IntegrationContainerTest.testRunPerformanceTestInContainer")
 }
 
+tasks.register<Test>("test-integration") {
+    filter.includeTestsMatching("host.IntegrationContainerTest.testRunIntegrationTestInContainer")
+}
+
 tasks.withType<Test> {
     useJUnitPlatform()
     group = "verification"


### PR DESCRIPTION
### Summary

Adds IAM Integration tests

### Description

- Added new gradle command `test-integration` for IAM, and later Secret Manager
  - In root dir, `cd testframework && .\gradlew --no-parallel test-integration --info`
- Spins up Aurora Postgres (APG) clusters
- Builds driver (AWS SDK, Library, and Driver) along with IAM tests
- Connection String Builder contains extra code that will be used for failover settings
- Disabled one test in IAM, `ConnectToIpAddress` due to a bug in the driver. The generated token using an IP as the hostname becomes an invalid password. This is occurring even outside of the integration test when running AWS CLI commands to generate the token. However, using the token with the Cluster URL, and connecting to IP is successful.

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
