### PR TITLE
Fix side-by-side installer conflict by changing installer GUIDs for `aws-pgsql-odbc`

### DIFF
--- a/installer/psqlodbc-setup/Bundle.wxs
+++ b/installer/psqlodbc-setup/Bundle.wxs
@@ -6,7 +6,7 @@
     <Bundle Name="awspsqlodbc"
 		Version="$(var.VERSION)"
 		Manufacturer="Amazon.com, Inc. or its affiliates"
-		UpgradeCode="7f9f14ee-2f3a-4120-a300-ee3fbd585627">
+		UpgradeCode="ce0f2014-8354-4497-9b94-b93fbe82fbf5">
 
 	<BootstrapperApplicationRef
 		Id="WixStandardBootstrapperApplication.RtfLicense">

--- a/installer/psqlodbc-setup/psqlodbc-setup.wixproj
+++ b/installer/psqlodbc-setup/psqlodbc-setup.wixproj
@@ -4,7 +4,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProductVersion>3.6</ProductVersion>
-    <ProjectGuid>{748caa18-f40d-4308-bc52-2605d09c38b1}</ProjectGuid>
+    <ProjectGuid>{01b20394-c534-40f6-8ee3-bcb394150d22}</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
     <OutputName>psqlodbc-setup</OutputName>
     <OutputType>Bundle</OutputType>

--- a/installer/psqlodbc_cpu.wxs
+++ b/installer/psqlodbc_cpu.wxs
@@ -5,18 +5,18 @@
 <?if $(sys.BUILDARCH) = x64 ?>
   <?define Platform = "x64" ?>
   <?define PKGNAME = "AWSpsqlODBC_x64" ?>
-  <?define CIDREG = "4D361F28-8F75-4c86-9A37-6C279967413D" ?>
-  <?define CIDDOC = "0C745A85-4E55-4bab-BBF1-DCF51D92FCC5" ?>
-  <?define CIDSMD = "{E6410EE8-96DC-4d84-8D07-94F8093BF3EF}" ?>
-  <?define UPGCOD = "BBD29DF5-89F6-4b8b-BDC9-C3EA3A4AFDBB" ?>
+  <?define CIDREG = "5761E547-D13B-4221-9A63-9E8A4FDF7B4A" ?>
+  <?define CIDDOC = "A7FAD2DB-B008-4321-B5C4-01AD6633A83F" ?>
+  <?define CIDSMD = "{5AE2E3A9-5F2E-4976-856F-740F999A1A11}" ?>
+  <?define UPGCOD = "B73906E3-C12A-4E04-ADEF-21A339013713" ?>
   <?define ALLUSERS = "1" ?>
 <?elseif $(sys.BUILDARCH) = x86 ?>
   <?define Platform = "x86" ?>
   <?define PKGNAME = "AWSpsqlODBC" ?>
-  <?define CIDREG = "4F0C04EB-ADCB-4fa8-B6A3-E9F74EA693F8" ?>
-  <?define CIDDOC = "89DDBC52-9F0D-4846-91DC-09EECC87E42E" ?>
-  <?define CIDSMD = "{22288E09-B3B6-4181-907F-676099C20125}" ?>
-  <?define UPGCOD = "24BCA538-75A2-4a7f-B236-C99EFC2145DE" ?>
+  <?define CIDREG = "C7A6F42B-2E96-4A8C-B567-C52864CFB841" ?>
+  <?define CIDDOC = "733AA28C-2BCF-46CB-90C1-38E333ECDBA1" ?>
+  <?define CIDSMD = "{D70C323C-9283-454C-B574-157FBB818BB2}" ?>
+  <?define UPGCOD = "8A494A40-15B2-4A26-9A46-D63D7B78A008" ?>
   <?define ALLUSERS = "1" ?>
 <?else?><!-- sys.BUILDARCH -->
   <?error Invalid build architecture ?>

--- a/installer/psqlodbcm_cpu.wxs
+++ b/installer/psqlodbcm_cpu.wxs
@@ -11,7 +11,7 @@
   <?define BIT64 = "yes" ?>
   <?define ANSIFOLDER = "x64_ANSI_Release" ?>
   <?define UNICODEFOLDER = "x64_Unicode_Release" ?>
-  <?define Module_PackageId = "970B6E07-7105-4d66-80FA-9E208952FB96" ?>
+  <?define Module_PackageId = "337DDF3C-462B-4659-8D10-0FF7A9D13700" ?>
   <?define InstallerVersion = "300" ?>
 <?if $(env.PROCESSOR_ARCHITECTURE) = "AMD64" ?>
   <?define SysFolder = "$(env.SystemRoot)\system32" ?>
@@ -24,7 +24,7 @@
   <?define BIT64 = "no" ?>
   <?define ANSIFOLDER = "x86_ANSI_Release" ?>
   <?define UNICODEFOLDER = "x86_Unicode_Release" ?>
-  <?define Module_PackageId = "ACF10866-5C01-46f0-90F0-D5618638CA48" ?>
+  <?define Module_PackageId = "AF6EA829-0091-4FAF-9946-734569A00642" ?>
   <?define InstallerVersion = "150" ?>
 <?if $(env.PROCESSOR_ARCHITECTURE) = "AMD64" ?>
   <?define SysFolder = "$(env.SystemRoot)\syswow64" ?>


### PR DESCRIPTION
### Summary

See https://github.com/orgs/aws/projects/237/views/3?pane=issue&itemId=76684070

### Description

Change the GUIDs used by `aws-pgsql-odbc` such that they do not match/conflict with GUIDs used by the original driver.

The screencast below shows both installed drivers and the config dialog working as expected for DSNs created with each driver.

https://github.com/user-attachments/assets/cb7a7df0-fbf1-4e48-8326-027bea7c366b

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
