### PR TITLE
fix: auth early return

### DIFF
--- a/test_integration/iam_authentication_integration_test.cc
+++ b/test_integration/iam_authentication_integration_test.cc
@@ -246,7 +246,7 @@ TEST_F(IamAuthenticationIntegrationTest, WrongUser) {
         msg, SQL_MAX_MESSAGE_LENGTH - 1, &stmt_length);
     EXPECT_EQ(SQL_SUCCESS, rc);
     const std::string state_str = reinterpret_cast<char*>(state);    
-    EXPECT_EQ("08S01", state_str);
+    EXPECT_EQ("08001", state_str);
 }
 
 // Tests that the IAM connection will fail when provided an empty user.
@@ -270,5 +270,5 @@ TEST_F(IamAuthenticationIntegrationTest, EmptyUser) {
         msg, SQL_MAX_MESSAGE_LENGTH - 1, &stmt_length);
     EXPECT_EQ(SQL_SUCCESS, rc);
     const std::string state_str = reinterpret_cast<char*>(state);
-    EXPECT_EQ("08S01", state_str);
+    EXPECT_EQ("08001", state_str);
 }


### PR DESCRIPTION
### Summary

Fixes several issues with authentication returns

### Description
- Created larger buffer for error message for any, if any. So rather than the generic failure to connect, we can also set custom messages
e.g.
![image](https://github.com/user-attachments/assets/987c9556-6d15-4ae9-ad1c-91ea969dcc33)
- Secret Manager returned successful connection early, not setting the proper values such as the initial settings, locale, etc.
- IAM auth was not returning early enough since the early fail was only checked if it was a cached token

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
