### PR TITLE
fix: use action to parse changelog

### DIFF
--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -195,14 +195,11 @@ jobs:
           pattern: installers-*
           merge-multiple: true
       - name: Set Version Env Variable
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: 'Get Release Details'
-        run: |
-          export RELEASE_DETAILS="$(awk -vN=2 'n<N;/^## /{++n}' CHANGELOG.md)"
-          export RELEASE_DETAILS="$(sed '${/^# /d;}' <<< "$RELEASE_DETAILS")"
-          export RELEASE_DETAILS="$(sed '$d' <<< "$RELEASE_DETAILS")"
-          touch RELEASE_DETAILS.md
-          echo "$RELEASE_DETAILS" > RELEASE_DETAILS.md
+        run: echo ("RELEASE_VERSION=" + $env:GITHUB_REF_NAME) >>  $env:GITHUB_ENV
+      - name: Extract release notes
+        uses: ffurrer2/extract-release-notes@v2
+        with:
+          release_notes_file: RELEASE_DETAILS.md
       - name: Upload to Draft Release
         uses: ncipollo/release-action@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/#semantic-versioning-200).
 
 ## [0.0.2] - 2024-11-27
+The Amazon Web Services (AWS) ODBC Driver for PostgreSQL allows an application to take advantage of additional authentication features such Okta Federated Service and AWS Secret Manager.
+
 ### :magic_wand: Added
 - [AWS Secret Manager authentication support](./docs/authentication.md#secret-manager-authentication)
 - [AWS Federated authentication method with OKTA](./docs/authentication.md#okta-authentication)


### PR DESCRIPTION
### Summary

fix: use action to parse changelog

### Description

- Uses an action to parse github changelogs instead.
- Previous workflow would complain about the `changelog.md` file is missing. This version has worked before, see this [release / commit](https://github.com/aws/aws-pgsql-odbc/releases/tag/untagged-75e8969b3356568712e5)

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
