### PR TITLE
chore: add required approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aws/atlas-dev-support


### PR DESCRIPTION
### Summary

Adds `atlas-dev-support` as required approvers for mainline

### Description

Adds a CODEOWNERS file to allow rulesets to enforce that code must be reviewed by someone on the `atlas-dev-support` team before a merge is done to mainline

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
