### PR TITLE
chore: codeowners subteam

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @aws/atlas-dev-support
+* @aws/atlas-aws-pgsql-odbc


### PR DESCRIPTION
### Summary

Changes Codeowners to subteam

### Description

Changes the codeowners team to a subteam to reduce the noise it would send to other teams

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
