### PR TITLE
fix: Properly close limitless monitor service on disconnection

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -397,10 +397,6 @@ CC_Destructor(ConnectionClass *self)
 	}
 	MYLOG(0, "after free statement holders\n");
 
-	if (self->connInfo.limitless_enabled) {
-		StopLimitlessMonitorService(self->connInfo.limitless_service_id);
-	}
-
 	NULL_THE_NAME(self->schemaIns);
 	NULL_THE_NAME(self->tableIns);
 	CC_conninfo_release(&self->connInfo);
@@ -769,6 +765,11 @@ CC_cleanup(ConnectionClass *self, BOOL keepCommunication)
 	{
 		free(self->discardp);
 		self->discardp = NULL;
+	}
+
+	// stop/decrease reference count for the limitless monitor service if enabled
+	if (self->connInfo.limitless_enabled) {
+		StopLimitlessMonitorService(self->connInfo.limitless_service_id);
 	}
 
 	LEAVE_CONN_CS(self);


### PR DESCRIPTION
### Summary

CC_Destructor isn't called as I expected; CC_cleanup is called on SQLDisconnect.

The StopLimitlessMonitorService function has been moved with respect to this.

### Description

See above.

### Additional Reviewers

- Keith Wedinger
- Colin Yuen
- Roy Zhang

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
