### PR TITLE
Use `MB_ICONINFORMATION` when the connection test is successful

### DIFF
--- a/setup.c
+++ b/setup.c
@@ -466,6 +466,7 @@ test_connection(HANDLE hwnd, ConnInfo *ci, BOOL withDTC)
 	SQLSMALLINT	str_len;
 	char		dsn_1st;
 	BOOL		connected = FALSE;
+    UINT        connection_test_icon = MB_ICONINFORMATION;
 #ifdef	UNICODE_SUPPORT
 	SQLWCHAR	wout_conn[MAX_CONNECT_STRING_LEN];
 	SQLWCHAR	szMsg[SQL_MAX_MESSAGE_LENGTH];
@@ -570,7 +571,11 @@ MYLOG(0, "conn_string=%s\n", out_conn);
 cleanup:
 	if (NULL != ermsg && NULL != hwnd)
 	{
-		MESSAGEBOXFUNC(hwnd, ermsg, _T("Connection Test"), MB_ICONEXCLAMATION | MB_OK);
+        if (!connected)
+        {
+            connection_test_icon = MB_ICONEXCLAMATION;
+        }
+        MESSAGEBOXFUNC(hwnd, ermsg, _T("Connection Test"), connection_test_icon | MB_OK);
 	}
 
 #undef _T


### PR DESCRIPTION
### Summary

https://github.com/orgs/aws/projects/237/views/3?pane=issue&itemId=97167636

### Description

Use `MB_ICONINFORMATION` inside the connection test message box when the connection is successful.

### Screenshots

#### Successful test

<img width="211" alt="Screenshot 2025-02-10 at 2 50 15 PM" src="https://github.com/user-attachments/assets/9422ee7b-a5ad-424e-9756-bb9dfc14c5b6" />

#### Failed test

<img width="411" alt="Screenshot 2025-02-10 at 2 49 52 PM" src="https://github.com/user-attachments/assets/ba760ce9-d876-466b-8165-e4673bcb90c9" />

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
