### PR TITLE
fix: limitless GUI bug

### DIFF
--- a/dlg_wingui.c
+++ b/dlg_wingui.c
@@ -458,7 +458,7 @@ limitless_optionsDraw(HWND hdlg, const ConnInfo *ci, int src, BOOL enable)
 		SendDlgItemMessage(hdlg, IDC_LIMITLESS_MODE, CB_ADDSTRING, 0, (WPARAM)buff);
 	}
 	SendDlgItemMessage(hdlg, IDC_LIMITLESS_MODE, CB_SETCURSEL, selidx, (WPARAM)0);
-	SetWindowSubclass(GetDlgItem(hdlg, IDC_LIMITLESS_MODE), ListBoxProc, 0, 0);
+	SetWindowSubclass(GetDlgItem(hdlg, IDC_LIMITLESS_MODE), DefSubclassProc, 0, 0);
 
 	limitless_optionsDlgEnable(hdlg, ci);
 


### PR DESCRIPTION
### Summary

ListBoxProc is only supposed to be used for the AuthType dropdown. It makes a call to the EnableWindows function which enables some auth related fields depending on the auth type.
Fixes: https://github.com/orgs/aws/projects/237/views/3?pane=issue&itemId=95409561

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
