### PR TITLE
chore: linux artifact release

### DIFF
--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -35,9 +35,81 @@ env:
   IODBC_VERSION: '3.52.16'
 
 jobs:
+  # Linux Build
+  build-linux:
+    if: false # Skip job, not for release
+    runs-on: ubuntu-latest
+    outputs:
+      linux_x64_ansi: ${{ steps.linux-x64-ansi.outputs.hash }}
+      linux_x64_unicode: ${{ steps.linux-x64-unicode.outputs.hash }}
+    env:
+      CMAKE_GENERATOR: Unix Makefiles
+    steps:
+      - name: Checkout aws-pgsql-odbc
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Checkout aws-rds-odbc
+        uses: actions/checkout@v4
+        with:
+          repository: aws/aws-rds-odbc
+          ref: main
+          path: ./libs/aws-rds-odbc
+          token: ${{secrets.CLONE_PAT}}
+
+      - name: Initialize submodules
+        run: |
+          git submodule update --init --recursive
+
+      - name: Download Prerequsites
+        run: |
+          sudo apt-get update
+          sudo apt-get install autoconf automake build-essential cmake curl g++-10 git grep libcurl4-openssl-dev libssl-dev libgflags-dev libodbc2 libodbcinst2 libpq-dev libtool-bin lsb-base lsb-release uuid-dev zlib1g-dev
+
+      - name: Download & Setup iODBC
+        run: |
+          curl -L https://github.com/openlink/iODBC/releases/download/v${{env.IODBC_VERSION}}/libiodbc-${{env.IODBC_VERSION}}.tar.gz -o libiodbc.tar
+          tar xf libiodbc.tar
+          cd libiodbc-${{env.IODBC_VERSION}}
+          ./configure && make
+          sudo make install
+
+      - name: Build Driver
+        run: |
+          sudo bash linux/buildall ${{env.BUILD_CONFIGURATION}} true false
+
+      - name: Get Ansi Driver Hash
+        id: linux-x64-ansi
+        run: |
+          hash=$(sha256sum ./.libs/awspsqlodbca.so | cut -d' ' -f1)
+          echo "hash=${hash}" >> "$GITHUB_OUTPUT"
+
+      - name: Get Unicode Driver Hash
+        id: linux-x64-unicode
+        run: |
+          hash=$(sha256sum ./.libs/awspsqlodbcw.so | cut -d' ' -f1)
+          echo "hash=${hash}" >> "$GITHUB_OUTPUT"
+
+      - name: Package Drivers as Tar
+        run:
+          tar -czvhf "aws-pgsql-odbc-${{ github.ref_name }}-linux-x64.tar.gz" ./.libs/awspsqlodbca.so ./.libs/awspsqlodbcw.so
+
+      - name: Upload the ANSI & Unicode driver
+        uses: actions/upload-artifact@v4
+        with:
+          name: installers-linux
+          path: |
+            aws-pgsql-odbc-${{ github.ref_name }}-linux-x64.tar.gz
+          retention-days: 5
+          if-no-files-found: error
+
   # Mac Build
   build-macos:
     runs-on: macos-15
+    outputs:
+      macos_arm64_ansi: ${{ steps.macos-arm64-ansi.outputs.hash }}
+      macos_arm64_unicode: ${{ steps.macos-arm64-unicode.outputs.hash }}
     steps:
       - name: Update Homebrew
         run: brew update && brew upgrade && brew cleanup
@@ -78,6 +150,18 @@ jobs:
 
       - name: Build the driver
         run: ./macos/buildall ${{env.BUILD_CONFIGURATION}}
+
+      - name: Get Ansi Driver Hash
+        id: macos-arm64-ansi
+        run: |
+          hash=$(shasum -a 256 ./.libs/awspsqlodbca.so | cut -d' ' -f1)
+          echo "hash=${hash}" >> "$GITHUB_OUTPUT"
+
+      - name: Get Unicode Driver Hash
+        id: macos-arm64-unicode
+        run: |
+          hash=$(shasum -a 256 ./.libs/awspsqlodbcw.so | cut -d' ' -f1)
+          echo "hash=${hash}" >> "$GITHUB_OUTPUT"
 
       - name: Package Drivers as Zip
         run:
@@ -186,64 +270,20 @@ jobs:
           retention-days: 5
           if-no-files-found: error
 
-  # Linux Build
-  build-linux:
-    runs-on: ubuntu-latest
-    env:
-      CMAKE_GENERATOR: Unix Makefiles
-    steps:
-      - name: Checkout aws-pgsql-odbc
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Checkout aws-rds-odbc
-        uses: actions/checkout@v4
-        with:
-          repository: aws/aws-rds-odbc
-          ref: main
-          path: ./libs/aws-rds-odbc
-          token: ${{secrets.CLONE_PAT}}
-
-      - name: Initialize submodules
-        run: |
-          git submodule update --init --recursive
-
-      - name: Download Prerequsites
-        run: |
-          sudo apt-get update
-          sudo apt-get install autoconf automake build-essential cmake curl g++-10 git grep libcurl4-openssl-dev libssl-dev libgflags-dev libodbc2 libodbcinst2 libpq-dev libtool-bin lsb-base lsb-release uuid-dev zlib1g-dev
-
-      - name: Download & Setup iODBC
-        run: |
-          curl -L https://github.com/openlink/iODBC/releases/download/v${{env.IODBC_VERSION}}/libiodbc-${{env.IODBC_VERSION}}.tar.gz -o libiodbc.tar
-          tar xf libiodbc.tar
-          cd libiodbc-${{env.IODBC_VERSION}}
-          ./configure && make
-          sudo make install
-
-      - name: Build Driver
-        run: |
-          sudo bash linux/buildall ${{env.BUILD_CONFIGURATION}} true false
-
-      - name: Package Drivers as Tar
-        run:
-          tar -czvhf "aws-pgsql-odbc-${{ github.ref_name }}-linux-x64.tar.gz" ./.libs/awspsqlodbca.so ./.libs/awspsqlodbcw.so
-
-      - name: Upload the ANSI & Unicode driver
-        uses: actions/upload-artifact@v4
-        with:
-          name: installers-linux
-          path: |
-            aws-pgsql-odbc-${{ github.ref_name }}-linux-x64.tar.gz
-          retention-days: 5
-          if-no-files-found: error
-
   # Create Release
   draft-release:
     name: Create Draft Release
     runs-on: ubuntu-latest
-    needs: [build-macos, build-windows]
+    needs: [
+      # build-linux,
+      build-macos,
+      build-windows
+    ]
+    env:
+      # linux_x64_ansi_hash: ${{needs.build-linux.outputs.linux_x64_ansi}}
+      # linux_x64_unicode_hash: ${{needs.build-linux.outputs.linux_x64_unicode}}
+      macos_arm64_ansi_hash: ${{needs.build-macos.outputs.macos_arm64_ansi}}
+      macos_arm64_unicode_hash: ${{needs.build-macos.outputs.macos_arm64_unicode}}
     steps:
       - name: Checkout aws-pgsql-odbc
         uses: actions/checkout@v4
@@ -261,6 +301,17 @@ jobs:
         uses: ffurrer2/extract-release-notes@v2
         with:
           release_notes_file: RELEASE_DETAILS.md
+
+      - name: Append Checksums
+        run: |
+          cat << EOF >> RELEASE_DETAILS.md
+
+          ### SHA256 Checksums
+
+          - macos-arm64-ansi: \`$macos_arm64_ansi_hash\`
+          - macos-arm64-unicode: \`$macos_arm64_unicode_hash\`
+
+          EOF
 
       - name: Upload to Draft Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
### Summary

Linux Artifact Builds for Release

### Description

- Adds workflow to build Linux Artifacts. This is not uploaded to the release but if needed can be found in the actions (5 day storage)
- Mac & Linux are compressed twice for upload, but on final release should only be the single tar/zip
- Fixed GitHub Releases not having any artifacts
- Fixed GitHub Releases not having a version in the title
- Adds checksum for the built drivers and published into the release notes

![image](https://github.com/user-attachments/assets/2aca2279-31dc-4c4c-81f1-7b5db3d1d38b)



### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
