### PR TITLE
chore: change ato... to strto...

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -1182,7 +1182,7 @@ TokenResult GetTokenForIAM(ConnInfo* ci, BOOL useCache) {
 		return TR_FAILURE;
 	}
 
-	int port = atoi(ci->port);
+	int port = pg_atoi(ci->port);
 	if (port < 1) {
 		port = 5432; // set to default port.
 	}
@@ -1241,7 +1241,7 @@ void GetLimitlessServer(ConnInfo *ci) {
 		return;
 	}
 
-	int host_port = atoi(ci->port);
+	int host_port = pg_atoi(ci->port);
 	ci->limitless_enabled = 0;
 	char connect_string_encoded[MAX_CONNECT_STRING];
 	makeConnectString(connect_string_encoded, ci, MAX_CONNECT_STRING);

--- a/dlg_specific.c
+++ b/dlg_specific.c
@@ -720,19 +720,19 @@ copyConnAttributes(ConnInfo *ci, const char *attribute, const char *value)
 	else if (stricmp(attribute, INI_SECRET_ID) == 0)
 		STRCPY_FIXED(ci->secret_id, value);
 	else if (stricmp(attribute, INI_LIMITLESS_ENABLED) == 0)
-		ci->limitless_enabled = atoi(value);
+		ci->limitless_enabled = pg_atoi(value);
 	else if (stricmp(attribute, INI_LIMITLESS_MODE) == 0)
 		STRCPY_FIXED(ci->limitless_mode, value);
 	else if (stricmp(attribute, INI_LIMITLESS_MONITOR_INTERVAL_MS) == 0)
-		ci->limitless_monitor_interval_ms = atoi(value);
+		ci->limitless_monitor_interval_ms = pg_atoi(value);
 	else if (stricmp(attribute, INI_LIMITLESS_SERVICE_ID) == 0)
 		STRCPY_FIXED(ci->limitless_service_id, value);
 	else if (stricmp(attribute, INI_LOGDIR) == 0)
         STRCPY_FIXED(ci->log_dir, value);
 	else if (stricmp(attribute, INI_RDSLOGGINGENABLED) == 0)
-        ci->rds_logging_enabled = atoi(value);
+        ci->rds_logging_enabled = pg_atoi(value);
 	else if (stricmp(attribute, INI_RDSLOGTHRESHOLD) == 0)
-        ci->rds_log_threshold = atoi(value);
+        ci->rds_log_threshold = pg_atoi(value);
 	else if (stricmp(attribute, INI_READONLY) == 0 || stricmp(attribute, ABBR_READONLY) == 0)
 		STRCPY_FIXED(ci->onlyread, value);
 	else if (stricmp(attribute, INI_PROTOCOL) == 0 || stricmp(attribute, ABBR_PROTOCOL) == 0)
@@ -1323,21 +1323,21 @@ MYLOG(MIN_LOG_LEVEL, "drivername=%s\n", drivername);
 	if (SQLGetPrivateProfileString(DSN, INI_CLUSTER_ID, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
 		STRCPY_FIXED(ci->cluster_id, temp);
 	if (SQLGetPrivateProfileString(DSN, INI_ENABLE_CLUSTER_FAILOVER, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->enable_failover = atoi(temp);
+		ci->enable_failover = pg_atoi(temp);
 	if (SQLGetPrivateProfileString(DSN, INI_FAILOVER_MODE, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
 		STRCPY_FIXED(ci->failover_mode, temp);
 	if (SQLGetPrivateProfileString(DSN, INI_FAILOVER_TIMEOUT, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->failover_timeout = atoi(temp);
+		ci->failover_timeout = pg_atoi(temp);
 	if (SQLGetPrivateProfileString(DSN, INI_HOST_PATTERN, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
 		STRCPY_FIXED(ci->host_pattern, temp);
 	if (SQLGetPrivateProfileString(DSN, INI_IGNORE_TOPOLOGY_REQUEST_RATE, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->ignore_topology_refresh = atoi(temp);
+		ci->ignore_topology_refresh = pg_atoi(temp);
 	if (SQLGetPrivateProfileString(DSN, INI_READER_STRATEGY, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
 		STRCPY_FIXED(ci->reader_host_selector_strategy, temp);
 	if (SQLGetPrivateProfileString(DSN, INI_TOPOLOGY_HIGH_REFRESH_RATE, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->topology_high_refresh = atoi(temp);
+		ci->topology_high_refresh = pg_atoi(temp);
 	if (SQLGetPrivateProfileString(DSN, INI_TOPOLOGY_REFRESH_RATE, NULL_STRING, temp, sizeof(temp), ODBC_INI) > 0)
-		ci->topology_refresh = atoi(temp);
+		ci->topology_refresh = pg_atoi(temp);
 
     /* Allow override of odbcinst.ini parameters here */
 	get_Ci_Drivers(DSN, ODBC_INI, &(ci->drivers));

--- a/psqlodbc.h
+++ b/psqlodbc.h
@@ -69,6 +69,14 @@
 #endif  /* __GNUC__ || __IBMC__ */
 #endif  /* __INCLUDE_POSTGRES_FE_H__ */
 
+/*
+ * safe string-to-number conversions
+ */
+#define pg_atoi(val) (int) strtol(val, NULL, 10)
+#define pg_atof(val) strtod(val, NULL)
+#define pg_atol(val) strtol(val, NULL, 10)
+#define pg_atoll(val) strtoll(val, NULL, 10)
+
 #ifdef	_MIMALLOC_
 #include <mimalloc.h>
 #define pg_malloc	mi_malloc


### PR DESCRIPTION
### Summary

chore: change ato... to strto... since ato... functions are deprecated.

Related upstream PR: https://github.com/postgresql-interfaces/psqlodbc/pull/103

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.

