### PR TITLE
chore: use session token for signer

### DIFF
--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -228,7 +228,7 @@ jobs:
         shell: cmd
         run: |
           dotnet tool install --global wix
-          wix extension add --global WixToolset.UI.wixext/5.0.2
+          wix extension add --global WixToolset.UI.wixext/6.0.0
 
       - name: Cache AWS SDK libraries
         id: cache-dynamic-aws-sdk
@@ -249,6 +249,7 @@ jobs:
           role-skip-session-tagging: true
           aws-access-key-id: ${{ secrets.AWS_BUILD_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_BUILD_SECRET_KEY }}
+          aws-session-token: ${{ secrets.AWS_BUILD_SESSION_TOKEN }}
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}


### PR DESCRIPTION
### Summary

Use Session Token for Signer

### Description

To invoke the signer, the credentials have been changed such that they are now temporary and will be required to be updated each time the signer workflow is required.

Wix updated to 6.0.0

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
