### PR TITLE
chore: copy driver logs to output

### DIFF
--- a/.github/workflows/windows-failover-integration-tests.yml
+++ b/.github/workflows/windows-failover-integration-tests.yml
@@ -399,10 +399,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
-          AWS_RDS_MONITORING_ROLE_ARN: ${{ secrets.AWS_RDS_MONITORING_ROLE_ARN }}
           RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-          TEST_IAM_USER: ${{ secrets.TEST_IAM_USER }}
-          DRIVER_PATH: ${{ github.workspace }}
+          IAM_USER: ${{ secrets.TEST_IAM_USER }}
           SECRETS_ARN: ${{ env.AURORA_CLUSTER_SECRETS_ARN }}
           TEST_SERVER: ${{ env.AURORA_CLUSTER_ENDPOINT }}
 
@@ -420,10 +418,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
-          AWS_RDS_MONITORING_ROLE_ARN: ${{ secrets.AWS_RDS_MONITORING_ROLE_ARN }}
           RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-          TEST_IAM_USER: ${{ secrets.TEST_IAM_USER }}
-          DRIVER_PATH: ${{ github.workspace }}
+          IAM_USER: ${{ secrets.TEST_IAM_USER }}
           SECRETS_ARN: ${{ env.AURORA_CLUSTER_SECRETS_ARN }}
           TEST_SERVER: ${{ env.AURORA_CLUSTER_ENDPOINT }}
 
@@ -466,6 +462,12 @@ jobs:
             --port 5432 `
             --cidr ${{ steps.ip.outputs.ipv4 }}/32 `
            *> $null;
+
+      - name: Copy Driver Logs
+        if: always()
+        shell: pwsh
+        run: |
+          Copy-Item -Path 'C:\*.log' -Destination '${{ github.workspace }}\logs'
 
       - name: Archive log results
         if: always()

--- a/.github/workflows/windows-limitless-integration-tests.yml
+++ b/.github/workflows/windows-limitless-integration-tests.yml
@@ -411,10 +411,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
-          AWS_RDS_MONITORING_ROLE_ARN: ${{ secrets.AWS_RDS_MONITORING_ROLE_ARN }}
           RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-          TEST_IAM_USER: ${{ secrets.TEST_IAM_USER }}
-          DRIVER_PATH: ${{ github.workspace }}
+          IAM_USER: ${{ secrets.TEST_IAM_USER }}
           SECRETS_ARN: ${{ env.LIMITLESS_CLUSTER_SECRETS_ARN }}
           TEST_SERVER: ${{ env.LIMITLESS_CLUSTER_ENDPOINT }}
 
@@ -432,10 +430,8 @@ jobs:
             AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
             AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
-            AWS_RDS_MONITORING_ROLE_ARN: ${{ secrets.AWS_RDS_MONITORING_ROLE_ARN }}
             RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-            TEST_IAM_USER: ${{ secrets.TEST_IAM_USER }}
-            DRIVER_PATH: ${{ github.workspace }}
+            IAM_USER: ${{ secrets.TEST_IAM_USER }}
             SECRETS_ARN: ${{ env.LIMITLESS_CLUSTER_SECRETS_ARN }}
             TEST_SERVER: ${{ env.LIMITLESS_CLUSTER_ENDPOINT }}
 
@@ -478,6 +474,12 @@ jobs:
             --port 5432 `
             --cidr ${{ steps.ip.outputs.ipv4 }}/32 `
            *> $null;
+
+      - name: Copy Driver Logs
+        if: always()
+        shell: pwsh
+        run: |
+          Copy-Item -Path 'C:\*.log' -Destination '${{ github.workspace }}\logs'
 
       - name: Archive log results
         if: always()


### PR DESCRIPTION
### Summary

Windows GH Actions, Copies the Driver Logs to Output to GH Artifacts

### Description

To have more information when debugging, copy over the Driver Logs which were stored on the `C:/` drive to the runner's driver of `D:/..some more paths../logs`

Also removes some unused environment variables.

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
