### PR TITLE
chore: remove pat from gh workflows

### DIFF
--- a/.github/workflows/dockerized-linux-integration-tests.yml
+++ b/.github/workflows/dockerized-linux-integration-tests.yml
@@ -35,15 +35,8 @@ jobs:
       - name: Checkout aws-pgsql-odbc
         uses: actions/checkout@v4
         with:
+          submodules: true
           fetch-depth: 1
-
-      - name: Checkout aws-rds-odbc
-        uses: actions/checkout@v4
-        with:
-          repository: aws/aws-rds-odbc
-          ref: main
-          path: ./libs/aws-rds-odbc
-          token: ${{secrets.CLONE_PAT}}
 
       - name: Initialize submodules
         run: |

--- a/.github/workflows/dockerized-linux-limitless-tests.yml
+++ b/.github/workflows/dockerized-linux-limitless-tests.yml
@@ -35,15 +35,8 @@ jobs:
       - name: Checkout aws-pgsql-odbc
         uses: actions/checkout@v4
         with:
+          submodules: true
           fetch-depth: 1
-
-      - name: Checkout aws-rds-odbc
-        uses: actions/checkout@v4
-        with:
-          repository: aws/aws-rds-odbc
-          ref: main
-          path: ./libs/aws-rds-odbc
-          token: ${{secrets.CLONE_PAT}}
 
       - name: Initialize submodules
         run: |

--- a/.github/workflows/dockerized-linux-regression-tests.yml
+++ b/.github/workflows/dockerized-linux-regression-tests.yml
@@ -35,15 +35,8 @@ jobs:
       - name: Checkout aws-pgsql-odbc
         uses: actions/checkout@v4
         with:
+          submodules: true
           fetch-depth: 1
-
-      - name: Checkout aws-rds-odbc
-        uses: actions/checkout@v4
-        with:
-          repository: aws/aws-rds-odbc
-          ref: main
-          path: ./libs/aws-rds-odbc
-          token: ${{secrets.CLONE_PAT}}
 
       - name: Initialize submodules
         run: |

--- a/.github/workflows/macos-regression-tests.yml
+++ b/.github/workflows/macos-regression-tests.yml
@@ -79,15 +79,8 @@ jobs:
       - name: Checkout aws-pgsql-odbc
         uses: actions/checkout@v4
         with:
+          submodules: true
           fetch-depth: 1
-
-      - name: Checkout aws-rds-odbc
-        uses: actions/checkout@v4
-        with:
-          repository: aws/aws-rds-odbc
-          ref: main
-          path: ./libs/aws-rds-odbc
-          token: ${{secrets.CLONE_PAT}}
 
       - name: Initialize submodules
         run: git submodule update --init --recursive

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -38,15 +38,8 @@ jobs:
       - name: Checkout aws-pgsql-odbc
         uses: actions/checkout@v4
         with:
+          submodules: true
           fetch-depth: 1
-
-      - name: Checkout aws-rds-odbc
-        uses: actions/checkout@v4
-        with:
-          repository: aws/aws-rds-odbc
-          ref: main
-          path: ./libs/aws-rds-odbc
-          token: ${{secrets.CLONE_PAT}}
 
       - name: Initialize submodules
         run: |
@@ -117,15 +110,8 @@ jobs:
       - name: Checkout aws-pgsql-odbc
         uses: actions/checkout@v4
         with:
+          submodules: true
           fetch-depth: 1
-
-      - name: Checkout aws-rds-odbc
-        uses: actions/checkout@v4
-        with:
-          repository: aws/aws-rds-odbc
-          ref: main
-          path: ./libs/aws-rds-odbc
-          token: ${{secrets.CLONE_PAT}}
 
       - name: Initialize submodules
         run: git submodule update --init --recursive
@@ -363,15 +349,8 @@ jobs:
       - name: Checkout aws-pgsql-odbc
         uses: actions/checkout@v4
         with:
+          submodules: true
           fetch-depth: 1
-
-      - name: Checkout aws-rds-odbc
-        uses: actions/checkout@v4
-        with:
-          repository: aws/aws-rds-odbc
-          ref: main
-          path: ./libs/aws-rds-odbc
-          token: ${{secrets.CLONE_PAT}}
 
       - name: Initialize submodules
         run: |

--- a/.github/workflows/windows-failover-integration-tests.yml
+++ b/.github/workflows/windows-failover-integration-tests.yml
@@ -248,15 +248,8 @@ jobs:
       - name: Checkout aws-pgsql-odbc
         uses: actions/checkout@v4
         with:
+          submodules: true
           fetch-depth: 1
-
-      - name: Checkout aws-rds-odbc
-        uses: actions/checkout@v4
-        with:
-          repository: aws/aws-rds-odbc
-          ref: main
-          path: ./libs/aws-rds-odbc
-          token: ${{secrets.CLONE_PAT}}
 
       - name: Initialize submodules
         run: |

--- a/.github/workflows/windows-limitless-integration-tests.yml
+++ b/.github/workflows/windows-limitless-integration-tests.yml
@@ -254,15 +254,8 @@ jobs:
       - name: Checkout aws-pgsql-odbc
         uses: actions/checkout@v4
         with:
+          submodules: true
           fetch-depth: 1
-
-      - name: Checkout aws-rds-odbc
-        uses: actions/checkout@v4
-        with:
-          repository: aws/aws-rds-odbc
-          ref: main
-          path: ./libs/aws-rds-odbc
-          token: ${{secrets.CLONE_PAT}}
 
       - name: Initialize submodules
         run: |

--- a/.github/workflows/windows-regression-tests.yml
+++ b/.github/workflows/windows-regression-tests.yml
@@ -247,15 +247,8 @@ jobs:
       - name: Checkout aws-pgsql-odbc
         uses: actions/checkout@v4
         with:
+          submodules: true
           fetch-depth: 1
-
-      - name: Checkout aws-rds-odbc
-        uses: actions/checkout@v4
-        with:
-          repository: aws/aws-rds-odbc
-          ref: main
-          path: ./libs/aws-rds-odbc
-          token: ${{secrets.CLONE_PAT}}
 
       - name: Initialize submodules
         run: |


### PR DESCRIPTION
### Summary

Removes PAT from GH Workflows

### Description

As both repositories are now public, we no longer need to clone using a PAT

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
