### PR TITLE
docs: Update OKTA, no 2FA Support

### DIFF
--- a/docs/using-the-aws-driver/authentication/okta_authentication.md
+++ b/docs/using-the-aws-driver/authentication/okta_authentication.md
@@ -1,6 +1,8 @@
 ## Okta Authentication
 The driver supports authentication via an [Okta](https://www.okta.com/) federated identity and then database access via IAM.
 
+However, the driver does not support 2FA. To disable 2FA for specific users or a groups, please read [Okta's article](https://support.okta.com/help/s/article/Exclude-from-OKta-Verify-MFA-user-doesn-t-have-a-phone?language=en_US) on how to do so.
+
 ### What is Federated Identity
 Federated Identity allows users to use the same set of credentials to access multiple services or resources across different organizations. This works by having Identity Providers (IdP) that manage and authenticate user credentials, and Service Providers (SP) that are services or resources that can be internal, external, and/or belonging to various organizations. Multiple SPs can establish trust relationships with a single IdP.
 

--- a/docs/using-the-aws-driver/authentication/okta_authentication.md
+++ b/docs/using-the-aws-driver/authentication/okta_authentication.md
@@ -1,7 +1,7 @@
 ## Okta Authentication
 The driver supports authentication via an [Okta](https://www.okta.com/) federated identity and then database access via IAM.
 
-However, the driver does not support 2FA. To disable 2FA for specific users or a groups, please read [Okta's article](https://support.okta.com/help/s/article/Exclude-from-OKta-Verify-MFA-user-doesn-t-have-a-phone?language=en_US) on how to do so.
+However, the driver does not support 2FA. To disable 2FA for specific users or a groups, please read [Okta's article](https://support.okta.com/help/s/article/Exclude-from-OKta-Verify-MFA-user-doesn-t-have-a-phone) on how to do so.
 
 ### What is Federated Identity
 Federated Identity allows users to use the same set of credentials to access multiple services or resources across different organizations. This works by having Identity Providers (IdP) that manage and authenticate user credentials, and Service Providers (SP) that are services or resources that can be internal, external, and/or belonging to various organizations. Multiple SPs can establish trust relationships with a single IdP.


### PR DESCRIPTION
### Summary

The driver doesn't support 2FA via Okta. This updates the docs to explicitly say so.

### Description

Updates the okta authentication docs under the authentication folder under using the driver, in docs.

### Additional Reviewers

- @ColinKYuen 

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
