### PR TITLE
chore: add run-attempt in clusterID for MacOS

### DIFF
--- a/.github/workflows/macos-integration-tests.yml
+++ b/.github/workflows/macos-integration-tests.yml
@@ -78,9 +78,9 @@ jobs:
           echo "AWS_SECRET_ACCESS_KEY=${creds[1]}" >> $GITHUB_ENV
           echo "AWS_SESSION_TOKEN=${creds[2]}" >> $GITHUB_ENV
 
-      - name: Setup Cluster Id and Shard Id Env Variables
+      - name: Setup Cluster ID
         run: |
-          echo "AURORA_CLUSTER_ID=AWS-PGODBC-MacOS-Integ-${{github.run_id}}" >> $GITHUB_ENV
+          echo "AURORA_CLUSTER_ID=AWS-PGODBC-MacOS-Integ-${{github.run_id}}${{github.run_attempt}}" >> $GITHUB_ENV
 
       - name: Create Aurora Cluster
         id: auroraClusterSetup


### PR DESCRIPTION
### Summary

Adds Actions RunAttempt suffix to Cluster ID

### Description

Addition of suffix allows us to rerun actions. Prior to this, secrets are made using the same name which makes it unable to rerun actions as deletion of secrets takes 30 days. It is not possible to create a secret with the same name as something that is currently deleting

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
