### PR TITLE
chore: use oidc provider for aws creds

### DIFF
--- a/.github/workflows/dockerized-linux-integration-tests.yml
+++ b/.github/workflows/dockerized-linux-integration-tests.yml
@@ -59,7 +59,6 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: pgodbc-linux-integration
-          role-duration-seconds: 21600
           output-credentials: true
 
       - name: Run Integration Tests

--- a/.github/workflows/dockerized-linux-integration-tests.yml
+++ b/.github/workflows/dockerized-linux-integration-tests.yml
@@ -24,6 +24,10 @@ concurrency:
   group: linux-integration-${{ github.ref }}
   cancel-in-progress: false # Do not cancel to ensure cleanup is ran
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   linux-integration-tests:
     name: Linux Integration Tests
@@ -49,25 +53,14 @@ jobs:
           java-version: 17
 
       - name: Configure AWS Credentials
+        id: creds
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-
-      - name: Set up Temp AWS Credentials
-        run: |
-          creds=($(aws sts get-session-token \
-            --duration-seconds 21600 \
-            --query 'Credentials.[AccessKeyId, SecretAccessKey, SessionToken]' \
-            --output text \
-          | xargs));
-          echo "::add-mask::${creds[0]}"
-          echo "::add-mask::${creds[1]}"
-          echo "::add-mask::${creds[2]}"
-          echo "TEMP_AWS_ACCESS_KEY_ID=${creds[0]}" >> $GITHUB_ENV
-          echo "TEMP_AWS_SECRET_ACCESS_KEY=${creds[1]}" >> $GITHUB_ENV
-          echo "TEMP_AWS_SESSION_TOKEN=${creds[2]}" >> $GITHUB_ENV
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+          role-session-name: pgodbc-linux-integration
+          role-duration-seconds: 21600
+          output-credentials: true
 
       - name: Run Integration Tests
         working-directory: ${{ github.workspace }}/testframework
@@ -78,10 +71,9 @@ jobs:
           TEST_DSN_UNICODE: 'psqlODBC_unicode'
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-          AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.TEMP_AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.TEMP_AWS_SESSION_TOKEN }}
-          AWS_RDS_MONITORING_ROLE_ARN: ${{ secrets.AWS_RDS_MONITORING_ROLE_ARN }}
+          AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.creds.outputs.aws-session-token }}
           RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           TEST_IAM_USER: ${{ secrets.TEST_IAM_USER }}
           DRIVER_PATH: ${{ github.workspace }}

--- a/.github/workflows/dockerized-linux-integration-tests.yml
+++ b/.github/workflows/dockerized-linux-integration-tests.yml
@@ -53,13 +53,11 @@ jobs:
           java-version: 17
 
       - name: Configure AWS Credentials
-        id: creds
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: pgodbc-linux-integration
-          output-credentials: true
 
       - name: Run Integration Tests
         working-directory: ${{ github.workspace }}/testframework
@@ -70,9 +68,6 @@ jobs:
           TEST_DSN_UNICODE: 'psqlODBC_unicode'
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-          AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
-          AWS_SESSION_TOKEN: ${{ steps.creds.outputs.aws-session-token }}
           RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           TEST_IAM_USER: ${{ secrets.TEST_IAM_USER }}
           DRIVER_PATH: ${{ github.workspace }}

--- a/.github/workflows/dockerized-linux-limitless-tests.yml
+++ b/.github/workflows/dockerized-linux-limitless-tests.yml
@@ -24,6 +24,10 @@ concurrency:
   group: linux-limitless-${{ github.ref }}
   cancel-in-progress: false # Do not cancel to ensure cleanup is ran
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   linux-limitless-integration-tests:
     name: Linux Limitless Integration Tests
@@ -49,25 +53,14 @@ jobs:
           java-version: 17
 
       - name: Configure AWS Credentials
+        id: creds
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-
-      - name: Set up Temp AWS Credentials
-        run: |
-          creds=($(aws sts get-session-token \
-            --duration-seconds 21600 \
-            --query 'Credentials.[AccessKeyId, SecretAccessKey, SessionToken]' \
-            --output text \
-          | xargs));
-          echo "::add-mask::${creds[0]}"
-          echo "::add-mask::${creds[1]}"
-          echo "::add-mask::${creds[2]}"
-          echo "TEMP_AWS_ACCESS_KEY_ID=${creds[0]}" >> $GITHUB_ENV
-          echo "TEMP_AWS_SECRET_ACCESS_KEY=${creds[1]}" >> $GITHUB_ENV
-          echo "TEMP_AWS_SESSION_TOKEN=${creds[2]}" >> $GITHUB_ENV
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+          role-session-name: pgodbc-linux-limitless
+          role-duration-seconds: 21600
+          output-credentials: true
 
       - name: Run Integration Tests
         working-directory: ${{ github.workspace }}/testframework
@@ -78,9 +71,9 @@ jobs:
           TEST_DSN_UNICODE: 'psqlODBC_unicode'
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-          AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.TEMP_AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.TEMP_AWS_SESSION_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.creds.outputs.aws-session-token }}
           AWS_RDS_MONITORING_ROLE_ARN: ${{ secrets.AWS_RDS_MONITORING_ROLE_ARN }}
           RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           TEST_IAM_USER: ${{ secrets.TEST_IAM_USER }}

--- a/.github/workflows/dockerized-linux-limitless-tests.yml
+++ b/.github/workflows/dockerized-linux-limitless-tests.yml
@@ -59,7 +59,6 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: pgodbc-linux-limitless
-          role-duration-seconds: 21600
           output-credentials: true
 
       - name: Run Integration Tests

--- a/.github/workflows/dockerized-linux-limitless-tests.yml
+++ b/.github/workflows/dockerized-linux-limitless-tests.yml
@@ -53,13 +53,11 @@ jobs:
           java-version: 17
 
       - name: Configure AWS Credentials
-        id: creds
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: pgodbc-linux-limitless
-          output-credentials: true
 
       - name: Run Integration Tests
         working-directory: ${{ github.workspace }}/testframework
@@ -70,9 +68,6 @@ jobs:
           TEST_DSN_UNICODE: 'psqlODBC_unicode'
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-          AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
-          AWS_SESSION_TOKEN: ${{ steps.creds.outputs.aws-session-token }}
           AWS_RDS_MONITORING_ROLE_ARN: ${{ secrets.AWS_RDS_MONITORING_ROLE_ARN }}
           RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           TEST_IAM_USER: ${{ secrets.TEST_IAM_USER }}

--- a/.github/workflows/macos-integration-tests.yml
+++ b/.github/workflows/macos-integration-tests.yml
@@ -38,6 +38,10 @@ concurrency:
   group: macos-integration-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   macos-integration-tests:
     name: "MacOS Integration Tests"
@@ -60,23 +64,11 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-
-      - name: Set up Temp AWS Credentials
-        run: |
-          creds=($(aws sts get-session-token \
-            --duration-seconds 21600 \
-            --query 'Credentials.[AccessKeyId, SecretAccessKey, SessionToken]' \
-            --output text \
-          | xargs));
-          echo "::add-mask::${creds[0]}"
-          echo "::add-mask::${creds[1]}"
-          echo "::add-mask::${creds[2]}"
-          echo "AWS_ACCESS_KEY_ID=${creds[0]}" >> $GITHUB_ENV
-          echo "AWS_SECRET_ACCESS_KEY=${creds[1]}" >> $GITHUB_ENV
-          echo "AWS_SESSION_TOKEN=${creds[2]}" >> $GITHUB_ENV
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+          role-session-name: pgodbc-macos-integration
+          role-duration-seconds: 21600
+          output-credentials: true
 
       - name: Setup Cluster ID
         run: |
@@ -105,10 +97,6 @@ jobs:
           . "./aws_rds_helper"
           endpoint=$(get_cluster_endpoint ${{ env.AURORA_CLUSTER_ID }})
           echo "AURORA_CLUSTER_ENDPOINT=$endpoint" >> $GITHUB_ENV
-        env:
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
 
       - name: Create Aurora Cluster Secrets
         shell: bash
@@ -162,9 +150,6 @@ jobs:
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
           TEST_SERVER: ${{ env.AURORA_CLUSTER_ENDPOINT }}
           POSTGRES_PORT: "5432"
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
           RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           IAM_USER: ${{ secrets.TEST_IAM_USER }}
           SECRETS_ARN: ${{ env.AURORA_CLUSTER_SECRETS_ARN }}
@@ -176,10 +161,6 @@ jobs:
         run: |
           . "./aws_rds_helper"
           delete_aurora_db_cluster ${{ env.AURORA_CLUSTER_ID }} ${{ secrets.AWS_DEFAULT_REGION }} ${{ env.NUM_AURORA_INSTANCES }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
 
       - name: Delete Aurora Cluster Secrets
         if: always()
@@ -188,10 +169,6 @@ jobs:
         run: |
           . "./aws_rds_helper"
           delete_secrets ${{ env.AURORA_CLUSTER_SECRETS_ARN }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
 
       - name: 'Get Github Action IP'
         if: always()

--- a/.github/workflows/macos-integration-tests.yml
+++ b/.github/workflows/macos-integration-tests.yml
@@ -67,8 +67,6 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: pgodbc-macos-integration
-          role-duration-seconds: 21600
-          output-credentials: true
 
       - name: Setup Cluster ID
         run: |

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -383,27 +383,21 @@ jobs:
           .\windows\buildall.ps1 ${{env.BUILD_CONFIGURATION}}
 
       - name: Configure AWS credentials OIDC
-        id: creds
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
           role-skip-session-tagging: true
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: pgodbc-win-signer
-          role-duration-seconds: 21600
-          output-credentials: true
 
       - name: Configure AWS credentials Signer
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
           role-skip-session-tagging: true
-          AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
-          AWS_SESSION_TOKEN: ${{ steps.creds.outputs.aws-session-token }}
+          role-chaining: true
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}
-          role-duration-seconds: 3600
 
       - name: Run signer script
         shell: pwsh

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -7,6 +7,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
+  id-token: write
   actions: write
   contents: write
   deployments: write
@@ -381,13 +382,24 @@ jobs:
           copy .github\workflows\configuration.xml winbuild
           .\windows\buildall.ps1 ${{env.BUILD_CONFIGURATION}}
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials OIDC
+        id: creds
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
           role-skip-session-tagging: true
-          aws-access-key-id: ${{ secrets.AWS_BUILD_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_BUILD_SECRET_KEY }}
-          aws-session-token: ${{ secrets.AWS_BUILD_SESSION_TOKEN }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+          role-session-name: pgodbc-win-signer
+          role-duration-seconds: 21600
+          output-credentials: true
+
+      - name: Configure AWS credentials Signer
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          role-skip-session-tagging: true
+          AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.creds.outputs.aws-session-token }}
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-external-id: ${{ secrets.AWS_ROLE_EXTERNAL_ID }}

--- a/.github/workflows/windows-failover-integration-tests.yml
+++ b/.github/workflows/windows-failover-integration-tests.yml
@@ -44,6 +44,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -283,25 +284,11 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-
-      - name: Set up Temp AWS Credentials
-        shell: pwsh
-        run: |
-          $creds = (aws sts get-session-token --duration-seconds 21600 --query 'Credentials.[AccessKeyId, SecretAccessKey, SessionToken]' --output text)
-          $credsArray = ($creds -split '\s+')
-          $credsArray | Measure-Object -Character
-          $access_key = $credsArray[0]
-          $secret_key = $credsArray[1]
-          $session_key = $credsArray[2]
-          echo "::add-mask::$access_key"
-          echo "::add-mask::$secret_key"
-          echo "::add-mask::$session_key"
-          echo "AWS_ACCESS_KEY_ID=$access_key" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "AWS_SECRET_ACCESS_KEY=$secret_key" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "AWS_SESSION_TOKEN=$session_key" | Out-File -FilePath $env:GITHUB_ENV -Append
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+          role-session-name: pgodbc-windows-failover
+          role-duration-seconds: 21600
+          output-credentials: true
 
       - name: Create Failover RDS Cluster
         id: AuroraClusterSetup
@@ -325,12 +312,7 @@ jobs:
         run: |
           . ".\aws_rds_helper.ps1"
           $endpoint = (Get-Cluster-Endpoint -ClusterId ${{ env.AURORA_CLUSTER_ID }})
-          echo "::add-mask::$endpoint"
           echo "AURORA_CLUSTER_ENDPOINT=$endpoint" | Out-File -FilePath $env:GITHUB_ENV -Append
-        env:
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
 
       - name: Create Aurora Cluster Secrets
         shell: pwsh
@@ -389,9 +371,6 @@ jobs:
           TEST_DSN: ${{ env.TEST_DSN_ANSI }}
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
           RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           IAM_USER: ${{ secrets.TEST_IAM_USER }}
           SECRETS_ARN: ${{ env.AURORA_CLUSTER_SECRETS_ARN }}
@@ -408,9 +387,6 @@ jobs:
           TEST_DSN: ${{ env.TEST_DSN_UNICODE }}
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
           RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           IAM_USER: ${{ secrets.TEST_IAM_USER }}
           SECRETS_ARN: ${{ env.AURORA_CLUSTER_SECRETS_ARN }}
@@ -423,10 +399,6 @@ jobs:
         run: |
           . ".\aws_rds_helper.ps1"
           Delete-Aurora-Db-Cluster -ClusterId ${{ env.AURORA_CLUSTER_ID }} -Region ${{ secrets.AWS_DEFAULT_REGION }} -NumInstances 5
-        env:
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
 
       - name: Delete Aurora Db Secrets
         if: always()
@@ -435,10 +407,6 @@ jobs:
         run: |
           . ".\aws_rds_helper.ps1"
           Delete-Secrets ${{ env.AURORA_CLUSTER_SECRETS_ARN }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
     
        # Make sure IP is always deleted
       - name: Get Github Action IP

--- a/.github/workflows/windows-failover-integration-tests.yml
+++ b/.github/workflows/windows-failover-integration-tests.yml
@@ -287,8 +287,6 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: pgodbc-windows-failover
-          role-duration-seconds: 21600
-          output-credentials: true
 
       - name: Create Failover RDS Cluster
         id: AuroraClusterSetup

--- a/.github/workflows/windows-limitless-integration-tests.yml
+++ b/.github/workflows/windows-limitless-integration-tests.yml
@@ -293,8 +293,6 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: pgodbc-windows-limitless
-          role-duration-seconds: 21600
-          output-credentials: true
 
       - name: Create Limitless RDS Cluster
         id: limitlessClusterSetup

--- a/.github/workflows/windows-limitless-integration-tests.yml
+++ b/.github/workflows/windows-limitless-integration-tests.yml
@@ -44,6 +44,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -289,26 +290,12 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
+          role-session-name: pgodbc-windows-limitless
+          role-duration-seconds: 21600
+          output-credentials: true
 
-      - name: Set up Temp AWS Credentials
-        shell: pwsh
-        run: |
-          $creds = (aws sts get-session-token --duration-seconds 21600 --query 'Credentials.[AccessKeyId, SecretAccessKey, SessionToken]' --output text)
-          $credsArray = ($creds -split '\s+')
-          $credsArray | Measure-Object -Character
-          $access_key = $credsArray[0]
-          $secret_key = $credsArray[1]
-          $session_key = $credsArray[2]
-          echo "::add-mask::$access_key"
-          echo "::add-mask::$secret_key"
-          echo "::add-mask::$session_key"
-          echo "AWS_ACCESS_KEY_ID=$access_key" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "AWS_SECRET_ACCESS_KEY=$secret_key" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "AWS_SESSION_TOKEN=$session_key" | Out-File -FilePath $env:GITHUB_ENV -Append
-      
       - name: Create Limitless RDS Cluster
         id: limitlessClusterSetup
         shell: pwsh
@@ -332,12 +319,7 @@ jobs:
         run: |
           . ".\aws_rds_helper.ps1"
           $endpoint = (Get-Cluster-Endpoint -ClusterId ${{ env.LIMITLESS_CLUSTER_ID }})
-          echo "::add-mask::$endpoint"
           echo "LIMITLESS_CLUSTER_ENDPOINT=$endpoint" | Out-File -FilePath $env:GITHUB_ENV -Append
-        env:
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
 
       - name: Install driver
         shell: pwsh
@@ -401,9 +383,6 @@ jobs:
           TEST_DSN: ${{ env.TEST_DSN_ANSI }}
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
           RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           IAM_USER: ${{ secrets.TEST_IAM_USER }}
           SECRETS_ARN: ${{ env.LIMITLESS_CLUSTER_SECRETS_ARN }}
@@ -420,9 +399,6 @@ jobs:
             TEST_DSN: ${{ env.TEST_DSN_UNICODE }}
             TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
             TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-            AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-            AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
             RDS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
             IAM_USER: ${{ secrets.TEST_IAM_USER }}
             SECRETS_ARN: ${{ env.LIMITLESS_CLUSTER_SECRETS_ARN }}
@@ -435,10 +411,6 @@ jobs:
         run: |
           . ".\aws_rds_helper.ps1"
           Delete-Limitless-Db-Cluster -ClusterId ${{ env.LIMITLESS_CLUSTER_ID }} -ShardId ${{ env.LIMITLESS_SHARD_ID }} -Region ${{ secrets.AWS_DEFAULT_REGION }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
 
       - name: Delete Limitless Db Secrets
         if: always()
@@ -447,10 +419,6 @@ jobs:
         run: |
           . ".\aws_rds_helper.ps1"
           Delete-Secrets ${{ env.LIMITLESS_CLUSTER_SECRETS_ARN }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
     
        # Make sure IP is always deleted
       - name: Get Github Action IP


### PR DESCRIPTION
### Summary

Uses OIDC to fetch AWS Credentials for Integration Testing & Signer Builds

### Description

Switches from using long term credentials to using OIDC to fetch AWS credentials for both integration testing and Window signer builds.

For the Windows build, this does a chained role assume as OIDC provider is on a different account than the signer.

Also created tag `0.0.0` to test signer. Will delete after workflow finishes / before merging.

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
