### PR TITLE
chore: Update Submodules

### DIFF
--- a/.github/workflows/macos-integration-tests.yml
+++ b/.github/workflows/macos-integration-tests.yml
@@ -142,12 +142,19 @@ jobs:
         run: |
           ./macos/buildall ${{ env.BUILD_TYPE }} FALSE
 
+      - name: 'Get Github Action IP'
+        if: always()
+        id: ip
+        uses: haythem/public-ip@v1.3
+
       - name: Build and Run ANSI Integration Tests
         shell: bash
         if: ${{ !cancelled() && steps.auroraClusterSetup.outcome == 'success'}}
         run: |
           cmake -S test_integration -B build_ansi -DUNICODE_BUILD=FALSE -DTEST_LIMITLESS=FALSE -DSHOULD_BUILD_FAILOVER=FALSE
           cmake --build build_ansi --config ${{ env.BUILD_TYPE }}
+          . ./macos/aws_rds_helper
+          add_ip_to_db_sg ${{ steps.ip.outputs.ipv4 }} ${{ env.AURORA_CLUSTER_ID }} ${{ secrets.AWS_DEFAULT_REGION }}
           ./build_ansi/bin/integration
         env:
           TEST_DSN_ANSI: ${{ env.TEST_DSN_ANSI }}
@@ -193,20 +200,15 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
 
-      - name: 'Get Github Action IP'
-        if: always()
-        id: ip
-        uses: haythem/public-ip@v1.3
-
       - name: 'Remove Github Action IP'
+        working-directory: macos
         if: always()
         run: |
-          aws ec2 revoke-security-group-ingress \
-            --group-name default \
-            --protocol tcp \
-            --port 5432 \
-            --cidr ${{ steps.ip.outputs.ipv4 }}/32 \
-          2>&1 > /dev/null;
+          . "./aws_rds_helper"
+          remove_ip_from_db_sg \
+            ${{ steps.ip.outputs.ipv4 }} \
+            ${{ env.AURORA_CLUSTER_ID }} \
+            ${{ secrets.AWS_DEFAULT_REGION }}
 
       - name: 'Archive log results'
         if: always()

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "libs/mimalloc"]
 	path = libs/mimalloc
 	url = https://github.com/microsoft/mimalloc
-	branch = master
+	branch = main
 [submodule "libs/aws-rds-odbc"]
 	path = libs/aws-rds-odbc
 	url = https://github.com/aws/aws-rds-odbc.git

--- a/macos/aws_rds_helper
+++ b/macos/aws_rds_helper
@@ -19,8 +19,9 @@ false=0
 
 # ---------------- Security Group Operations ----------------------
 function add_ip_to_db_sg {
-    ClusterId=$1
-    Region=$2
+    LocalIp=$1
+    ClusterId=$2
+    Region=$3
 
     # Get the security group associated with the DB cluster using AWS CLI
     dbClusterInfo=$(aws rds describe-db-clusters --db-cluster-identifier $ClusterId --region $Region)
@@ -38,19 +39,19 @@ function add_ip_to_db_sg {
     fi
 
     securityGroupId=$(echo "$dbClusterInfo" | jq -r '.DBClusters[0].VpcSecurityGroups[0].VpcSecurityGroupId')
-
-    # Get the local IP address of the machine running the script
-    localIp=$(curl "http://checkip.amazonaws.com")
-    cidrBlock="$localIp/32"
+    cidrBlock="$LocalIp/32"
 
     # Allow inbound traffic from the local IP address to the DB security group using AWS CLI
     aws ec2 authorize-security-group-ingress --group-id $securityGroupId --protocol tcp --cidr $cidrBlock --port 5432 --region $Region || true
+    echo "Waiting 30 seconds for security group to update..."
+    sleep 30
 } # function add_ip_to_db_sg
 export -f add_ip_to_db_sg
 
 function remove_ip_from_db_sg {
-    ClusterId=$1
-    Region=$2
+    LocalIp=$1
+    ClusterId=$2
+    Region=$3
 
     # Get the security group associated with the DB cluster using AWS CLI
     dbClusterInfo=$(aws rds describe-db-clusters --db-cluster-identifier $ClusterId --region $Region)
@@ -70,20 +71,17 @@ function remove_ip_from_db_sg {
     # Extract the Security Group ID
     securityGroupId=$(echo "$dbClusterInfo" | jq -r '.DBClusters[0].VpcSecurityGroups[0].VpcSecurityGroupId')
 
-    # Get the local IP address of the machine running the script
-    localIp=$(curl "http://checkip.amazonaws.com")
-
     # Define the CIDR block for the local IP address (allowing all ports and all traffic)
-    cidrBlock="$localIp/32"
+    cidrBlock="$LocalIp/32"
 
     # Revoke Inbound traffic
-    aws ec2 revoke-security-group-ingress --group-id $securityGroupId --protocol tcp --cidr $cidrBlock --port 0-65535 --region $Region
+    aws ec2 revoke-security-group-ingress --group-id $securityGroupId --protocol tcp --cidr $cidrBlock --port 5432 --region $Region || true
 
     # Check if revoked successfully
     if [ $? -eq 0 ]; then
-        echo "Removed IP: $localIp from security group $securityGroupId."
+        echo "Removed IP: $LocalIp from security group $securityGroupId."
     else
-        echo "Failed to remove ip $localIp from security group $securityGroupId."
+        echo "Failed to remove ip $LocalIp from security group $securityGroupId."
     fi
 } # function remove_ip_from_db_sg
 export -f remove_ip_from_db_sg
@@ -144,8 +142,6 @@ function create_aurora_rds_cluster {
 
     aws rds wait db-instance-available\
         --filters "Name=db-cluster-id,Values=${ClusterId}"
-
-    add_ip_to_db_sg $ClusterId $Region
 } # function create_aurora_rds_cluster
 export -f create_aurora_rds_cluster
 
@@ -238,8 +234,6 @@ function create_limitless_rds_cluster {
     else
         echo "Successfully detected DB cluster availability."
     fi
-
-    add_ip_to_db_sg $ClusterId $Region
 } # function create_limitless_rds_cluster
 export -f create_limitless_rds_cluster
 
@@ -281,7 +275,6 @@ function delete_aurora_db_cluster {
     Region=$2
     NumInstances=$3
 
-    remove_ip_from_db_sg $ClusterId $Region
     delete_dbinstances $ClusterId $NumInstances
     delete_dbcluster $ClusterId
 } # delete_aurora_db_cluster
@@ -292,7 +285,6 @@ function delete_limitless_db_cluster {
     ShardId=$2
     Region=$3
 
-    remove_ip_from_db_sg $ClusterId $Region
     # Retry settings
     maxRetries=5
     attempt=0

--- a/macos/aws_rds_helper
+++ b/macos/aws_rds_helper
@@ -43,8 +43,6 @@ function add_ip_to_db_sg {
 
     # Allow inbound traffic from the local IP address to the DB security group using AWS CLI
     aws ec2 authorize-security-group-ingress --group-id $securityGroupId --protocol tcp --cidr $cidrBlock --port 5432 --region $Region || true
-    echo "Waiting 30 seconds for security group to update..."
-    sleep 30
 } # function add_ip_to_db_sg
 export -f add_ip_to_db_sg
 

--- a/winbuild/BuildAll.ps1
+++ b/winbuild/BuildAll.ps1
@@ -120,7 +120,7 @@ function buildPlatform([xml]$configInfo, [string]$Platform)
 		}
 
 		# build mimalloc dependency
-		& ${msbuildexe} ..\libs\mimalloc\ide\$mimallocIdeDir\mimalloc.vcxproj /tv:$MSToolsV "/p:Platform=$Platform;Configuration=$Configuration;PlatformToolset=${Toolset}" /t:$target /p:VisualStudioVersion=${VCVersion}
+		& ${msbuildexe} ..\libs\mimalloc\ide\$mimallocIdeDir\mimalloc-lib.vcxproj /tv:$MSToolsV "/p:Platform=$Platform;Configuration=$Configuration;PlatformToolset=${Toolset}" /t:$target /p:VisualStudioVersion=${VCVersion}
 	}
 
 	# build psqlodbc

--- a/winbuild/psqlodbc.vcxproj
+++ b/winbuild/psqlodbc.vcxproj
@@ -147,7 +147,7 @@
     <ADD_DEFINES>$(ADD_DEFINES);_MIMALLOC_</ADD_DEFINES>
     <ADD_INC>$(ADD_INC);..\libs\mimalloc\include</ADD_INC>
     <ADD_LIBPATH>$(ADD_LIBPATH);..\libs\mimalloc\out\msvc-$(Platform)\$(Configuration)</ADD_LIBPATH>
-    <CALL_LIB>$(CALL_LIB);mimalloc-static.lib</CALL_LIB>
+    <CALL_LIB>$(CALL_LIB);mimalloc.lib</CALL_LIB>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">


### PR DESCRIPTION
### Summary

Updates mimalloc.

### Description

mimalloc master branch no longer exists - it seems they have migrated to the main branch naming convention.

The mimalloc.vcxproj file previously used to build mimalloc no longer exists - it is now mimalloc-lib.vcxproj ([which is specifically for building the static library](https://github.com/microsoft/mimalloc?tab=readme-ov-file#windows)). The driver now builds using the mimalloc-lib.vcxproj file.

The mimalloc-static.lib file is now built as mimalloc.lib. The driver now links against the mimalloc.lib file.

Also fixes the macos integration tests not revoking the correct IP address after tests are run.

### Additional Reviewers

- @ColinKYuen 

### By submitting this pull request, I confirm that my contribution is made under the terms of the LGPL-2.0 license.
